### PR TITLE
Fix authentication method

### DIFF
--- a/app/api/api_v1.rb
+++ b/app/api/api_v1.rb
@@ -225,9 +225,9 @@ class API_v1 < Grape::API
     post '/authenticate' do
       user = nil
       if params[:username]
-        user = User.where("LOWER(name) = ?", params[:username]).first
+        user = User.where("LOWER(name) = ?", params[:username].downcase).first
       elsif params[:email]
-        user = User.where("LOWER(email) = ?", params[:email]).first
+        user = User.where("LOWER(email) = ?", params[:email].downcase).first
       end
       if user.nil? or (not user.valid_password? params[:password])
         error!("Invalid credentials", 401)


### PR DESCRIPTION
Since you match with `LOWER()` you should also `.downcase` what you receive.  The API documentation doesn't describe this caveat, so I'm assuming it's a bug.

Also, this is 1000000000% untested, since, y'know, there's no test db or anything.

(P.S. - first pull request GET)
