### PR TITLE
Add CSRF token to AJAX, should fix sign out issues

### DIFF
--- a/app/assets/javascripts/initializers/csrf-token.js
+++ b/app/assets/javascripts/initializers/csrf-token.js
@@ -1,0 +1,14 @@
+Ember.Application.initializer({
+  name: 'csrf-token',
+  initialize: function () {
+    var csrfToken = $('meta[name="csrf-token"]').attr('content');
+    var csrfParam = $('meta[name="csrf-param"]').attr('content');
+    $.ajaxPrefilter(function(options, originalOptions, jqXHR) {
+      if (!options.crossDomain && csrfToken && csrfParam) {
+        var newData = {};
+        newData[csrfParam] = csrfToken;
+        options.data = $.param($.extend(originalOptions.data, newData));
+      }
+    });
+  }
+});


### PR DESCRIPTION
Based on the discussion on [the forums](http://forums.hummingbird.me/t/sign-out-button-does-nothing-when-viewing-a-users-library/5619), this adds the CSRF token to AJAX using `jQuery.ajaxPrefilter`.

I optimized a bit more than your examples of other solutions, by creating closed-over variables for the csrfToken and csrfParam, instead of loading them from DOM before every request.

I actually tested this code too, since I got the project running locally.  Seems to work like a charm, but it could have unintended side effects that I didn't notice.
#### Caveats:

I wasn't sure what the JS style ought to be so I just went with semicolons and 2-space indents based on nearby files &mdash; if you would prefer something else (I know I'd prefer tabs lol) I'll amend the commit.  You should probably add a short style guide (with stuff like indentation and semicolon-usage) to `CONTRIBUTING.md`.

Also I have no idea where else to cram it so I just put it in the `lib/` JS directory.  Once again, if this is wrong, I can amend the commit and force-push
