### PR TITLE
Hide loading indicator on dashboard and profile

### DIFF
--- a/app/assets/javascripts/templates/dashboard.emblem
+++ b/app/assets/javascripts/templates/dashboard.emblem
@@ -66,5 +66,6 @@
 
       each content itemController="story" itemViewClass="Hummingbird.StoryView"
       
-      load-more classNames="light" action="loadNextPage"
+      if canLoadMore
+        load-more classNames="light" action="loadNextPage"
 

--- a/app/assets/javascripts/templates/user/index.emblem
+++ b/app/assets/javascripts/templates/user/index.emblem
@@ -146,5 +146,6 @@
 
       each content itemController="story" itemViewClass="Hummingbird.StoryView"
 
-      load-more classNames="light" action="loadNextPage"
+      if canLoadMore
+        load-more classNames="light" action="loadNextPage"
 


### PR DESCRIPTION
To elaborate, this is not related to the request timeout issue that reportedly showed up after upgrading to Rails 4.1. It's just that the loading indicator doesn't disappear even after there's nothing else to load.

Example:
http://hummingbird.me/users/erengy

Would this fix the issue? All other instances of `load-more` have the `if canLoadMore` condition.
