### PR TITLE
Fixed several jQuery requests using 'failure' instead of 'error'

### DIFF
--- a/app/assets/javascripts/controllers/dashboard_controller.js
+++ b/app/assets/javascripts/controllers/dashboard_controller.js
@@ -80,7 +80,7 @@ Hummingbird.DashboardController = Ember.Controller.extend({
             });
             window.location.href = window.location.href;
           },
-          failure: function () {
+          error: function () {
             return alert("Failed to save comment");
           }
         });

--- a/app/assets/javascripts/controllers/story_controller.js
+++ b/app/assets/javascripts/controllers/story_controller.js
@@ -77,7 +77,7 @@ Hummingbird.StoryController = Ember.ObjectController.extend({
             return userIndexCon.get('target').send('reloadFirstPage');
           }
         },
-        failure: function () {
+        error: function () {
           return alert("Could not delete post");
         }
       });

--- a/app/assets/javascripts/controllers/user_index_controller.js
+++ b/app/assets/javascripts/controllers/user_index_controller.js
@@ -103,7 +103,7 @@ Hummingbird.UserIndexController = Ember.ArrayController.extend({
           data: data
         },
         method: 'POST',
-        failure: function () {
+        error: function () {
           return console.log("Failed to Update Favorites Ranks");
         }
       });
@@ -165,7 +165,7 @@ Hummingbird.UserIndexController = Ember.ArrayController.extend({
             });
             window.location.href = window.location.href;
           },
-          failure: function () {
+          error: function () {
             return alert("Failed to save comment");
           }
         });


### PR DESCRIPTION
'failure' is never called. It should instead say 'error'.
If comment.json continues to say Error 500, this will result in posts on the dashboard saying 'Failure to save comment', so it's probably best to sort that issue out before merging these.
