### PR TITLE
Fixed broken images on header search

### DIFF
--- a/app/assets/javascripts/controllers/header_controller.js
+++ b/app/assets/javascripts/controllers/header_controller.js
@@ -28,8 +28,9 @@ Hummingbird.HeaderController = Ember.Controller.extend({
         filter: function (results) {
           return Ember.$.map(results.search, function (r) {
             // There actually has to be a way to send the img params to the thumb generator in the request, this is just a temp. solution
-            if (r.type=="user")
+            if (r.type=="user") {
               r.image = r.image.replace(/(\.[a-zA-Z]+)?\?/, ".jpg?")
+            }
             return {
               title: r.title,
               type: r.type,


### PR DESCRIPTION
Fixes http://forums.hummingbird.me/t/some-thumbnails-dont-show-up-in-the-search-suggestions/10281

The if statement is necessary because, while all small user avatars end in .jpg, medium anime avatars can end in anything. Also, small HB anime avatars do not exist, hence why I used medium.
eg. avatars (always go to jpg)
http://static.hummingbird.me/users/avatars/000/007/884/thumb/insta.gif?1402522729
-> http://static.hummingbird.me/users/avatars/000/007/884/small/insta.jpg?1402522729
eg. anime (extension stays the same, so it can be anything. in this case, png)
http://static.hummingbird.me/anime/poster_images/000/007/442/large/7442.png?1383501242
-> http://static.hummingbird.me/anime/poster_images/000/007/442/medium/7442.png?1383501242
