### PR TITLE
Update deprecated find_or_create_by_ method

### DIFF
--- a/app/controllers/recommendations_controller.rb
+++ b/app/controllers/recommendations_controller.rb
@@ -63,7 +63,7 @@ class RecommendationsController < ApplicationController
 
   def plan_to_watch
     anime = Anime.find params[:anime]
-    watchlist = Watchlist.find_or_create_by_anime_id_and_user_id(anime.id, current_user.id)
+    watchlist = Watchlist.find_or_create_by(anime_id: anime.id, user_id: current_user.id)
     watchlist.status = "Plan to Watch"
     watchlist.save
     mixpanel.track "Recommendations: Plan to Watch", {email: current_user.email, anime: anime.slug} if Rails.env.production?


### PR DESCRIPTION
This PR fixes Issue #53.

```
Started POST "/recommendations/plan_to_watch" for 127.0.0.1 at 2014-06-14 02:28:01 -0700
Processing by RecommendationsController#plan_to_watch as */*
  Parameters: {"anime"=>"mirai-nikki-tv"}
  [1m[36mUser Load (1.7ms)[0m  [1mSELECT  "users".* FROM "users"  WHERE "users"."id" = 1  ORDER BY "users"."id" ASC LIMIT 1[0m
  [1m[35mAnime Load (1.5ms)[0m  SELECT  "anime".* FROM "anime"  WHERE "anime"."slug" = 'mirai-nikki-tv'  ORDER BY "anime"."id" ASC LIMIT 1
Completed 500 Internal Server Error in 12ms

NoMethodError - undefined method `find_or_create_by_anime_id_and_user_id' for #<Class:0x007f807084b6e0>:
```

The deprecated method `find_or_create_by_...` is still being used in certain places but they seem to be unused, below are the following places:
- `admin_controller#invite_to_beta`
- `watchlist_controller.rb`
- `import.rake#casting`

@vikhyat, do you want me to patch these as well? or are you planning on ripping them out.
