### PR TITLE
Fix status button on dashboard

### DIFF
--- a/app/assets/stylesheets/globals/_buttons.css.scss
+++ b/app/assets/stylesheets/globals/_buttons.css.scss
@@ -58,6 +58,7 @@ a {
   color: #fff !important;
   transition: ease-in .2s;
   padding: 5px 20px;
+  position: relative;
   margin-bottom: 5px;
   &:hover {
     background-color: darken($darkOrange, 2);


### PR DESCRIPTION
![fix-status-button](https://cloud.githubusercontent.com/assets/1078430/3279431/7d02126c-f3fb-11e3-9603-2e0422bbbea5.gif)

http://forums.hummingbird.me/t/feed-post-button-problem/10346

At first I tried to modify `.status-form` by shortening its height and adding a bottom margin, but seems like `append: '\n'` setting of the autosize plugin is there for a good reason. So I went for this instead.
