### PR TITLE
Fix waifu_slug resetting to #

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -347,10 +347,8 @@ class User < ActiveRecord::Base
       self.authentication_token = token
     end
 
-    if waifu_char_id != '0000' and changed_attributes['waifu_char_id'] and waifu_character
-      self.waifu_slug = waifu_character.anime.slug || '#'
-    else
-      self.waifu_slug = '#'
+    if waifu_char_id != '0000' and changed_attributes['waifu_char_id']
+      self.waifu_slug = waifu_character ? waifu_character.anime.slug : '#'
     end
   end
 


### PR DESCRIPTION
This PR fixes the bug posted [here](http://forums.hummingbird.me/t/waifu-husbando-doesnt-link-to-anime/9135)

Updating the user model, would cause the `waifu_slug` to be reset to `#` when it wasn't apart of the changed_attributes
