### PR TITLE
Stop cleaning the XML, since MAL seems to do valid XML in "export"

### DIFF
--- a/lib/my_anime_list_import.rb
+++ b/lib/my_anime_list_import.rb
@@ -1,17 +1,4 @@
 class MyAnimeListImport
-  VALID_XML_CHARS = /^(
-      [\x09\x0A\x0D\x20-\x7E] # ASCII
-    | [\xC2-\xDF][\x80-\xBF] # non-overlong 2-byte
-    | \xE0[\xA0-\xBF][\x80-\xBF] # excluding overlongs
-    | [\xE1-\xEC\xEE][\x80-\xBF]{2} # straight 3-byte
-    | \xEF[\x80-\xBE]{2} #
-    | \xEF\xBF[\x80-\xBD] # excluding U+fffe and U+ffff
-    | \xED[\x80-\x9F][\x80-\xBF] # excluding surrogates
-    | \xF0[\x90-\xBF][\x80-\xBF]{2} # planes 1-3
-    | [\xF1-\xF3][\x80-\xBF]{3} # planes 4-15
-    | \xF4[\x80-\x8F][\x80-\xBF]{2} # plane 16
-  )*$/nx;
-
   STATUS_MAP = {
     "1"             => "Currently Watching",
     "watching"      => "Currently Watching",
@@ -33,20 +20,13 @@ class MyAnimeListImport
   def initialize(user, xml)
     @user = user
     @xml = xml
-
-    # We need to do this because MAL returns broken XML. We need to get rid of
-    # characters that break Hash.from_xml.
-    # TODO: This does not get rid of all of the errors. Use xmllint instead of
-    #       all of this. (See issue #1 on Github)
-    @clean_xml = @xml.encode('ASCII-8BIT', invalid: :replace, undef: :replace, replace: '').split('').select {|x| x =~ VALID_XML_CHARS }.join.encode('UTF-8')
-
     @data = nil
   end
 
   def data
     if @data.nil?
       @data = []
-      hashdata = Hash.from_xml(@clean_xml)
+      hashdata = Hash.from_xml(@xml)
       hashdata = hashdata["myanimelist"]["anime"]
       hashdata.each do |indv|
         parsd = {


### PR DESCRIPTION
Looks like the stuff they cough up in the "export" thing is actually valid.  Should close #1

Haven't tested (automated or by hand) but most of the "broken" xml files seem to work fine directly in Nokogiri, so it should work.

Might add a test in morning, just really really tired right now
