### PR TITLE
Expose anime IDs in APIv1 and APIv2

### DIFF
--- a/app/api/api_v1.rb
+++ b/app/api/api_v1.rb
@@ -84,6 +84,7 @@ class API_v1 < Grape::API
     def present_anime(anime, title_language_preference, include_genres=true)
       if anime
         json = {
+          id: anime.id,
           slug: anime.slug,
           status: anime.status,
           url: "http://hummingbird.me/anime/#{anime.slug}",
@@ -106,22 +107,9 @@ class API_v1 < Grape::API
     def present_favorite_anime(anime, title_language_preference, include_genres=true)
       if anime
         fav_anime = Anime.find(anime.item_id)
-        json = {
-          slug: fav_anime.slug,
-          status: fav_anime.status,
-          url: "http://hummingbird.me/anime/#{fav_anime.slug}",
-          title: fav_anime.canonical_title(title_language_preference),
-          alternate_title: fav_anime.alternate_title(title_language_preference),
-          episode_count: fav_anime.episode_count,
-          cover_image: fav_anime.poster_image_thumb,
-          synopsis: fav_anime.synopsis,
-          show_type: fav_anime.show_type,
-          fav_rank: anime.fav_rank,
-          fav_id: anime.id
-        }
-        if include_genres
-          json[:genres] = fav_anime.genres.map {|x| {name: x.name} }
-        end
+        json = present_anime(fav_anime, title_language_preference, include_genres)
+        json[:fav_rank] = anime.fav_rank
+        json[:fav_id] = anime.id
         json
       else
         {}

--- a/app/api/entities.rb
+++ b/app/api/entities.rb
@@ -10,6 +10,7 @@ module Entities
       "/anime/#{anime.slug}"
     end
 
+    expose :id
     expose :slug
     expose :status
     expose(:url) {|anime, options| anime_path(anime) }

--- a/app/controllers/api/v2/api_controller.rb
+++ b/app/controllers/api/v2/api_controller.rb
@@ -9,7 +9,8 @@ module Api::V2
     # Presenters.
     def present_anime(anime)
       {
-        id: anime.slug,
+        id: anime.id,
+        slug: anime.slug,
         canonical_title: anime.canonical_title,
         english_title: nfb(anime.alt_title),
         romaji_title: nfb(anime.title),

--- a/app/serializers/anime_serializer.rb
+++ b/app/serializers/anime_serializer.rb
@@ -2,6 +2,7 @@ class AnimeSerializer < ActiveModel::Serializer
   embed :ids
 
   attributes :id,
+             :slug,
              :canonical_title,
              :english_title,
              :romaji_title,
@@ -16,10 +17,6 @@ class AnimeSerializer < ActiveModel::Serializer
              :started_airing_date_known,
              :finished_airing,
              :genres
-
-  def id
-    object.slug
-  end
 
   def english_title
     object.alt_title

--- a/test/controllers/api/v2/anime_controller_test.rb
+++ b/test/controllers/api/v2/anime_controller_test.rb
@@ -4,5 +4,8 @@ class Api::V2::AnimeControllerTest < ActionController::TestCase
   test "can get anime" do
     get :show, id: 'sword-art-online'
     assert_response 200
+
+    get :show, id: '6589'
+    assert_response 200
   end
 end

--- a/test/fixtures/anime.yml
+++ b/test/fixtures/anime.yml
@@ -38,6 +38,7 @@
 #
 
 sword_art_online:
+  id: 6589
   title: Sword Art Online
   alt_title: ''
   slug: sword-art-online
@@ -70,6 +71,7 @@ sword_art_online:
   ann_id:
 
 monster:
+  id: 10
   title: Monster
   alt_title: ''
   slug: monster


### PR DESCRIPTION
This should take care of issue #12, for the most part. While I'm on it, I removed redundant code in `present_favorite_anime` and added a test case too.
