### PR TITLE
Quick hack to css to fix pagination float issue.

### DIFF
--- a/public/old-application.css
+++ b/public/old-application.css
@@ -5068,6 +5068,7 @@ ul.pagination {
   display: block;
   height: 1.5em;
   margin-left: -0.3125em;
+  clear: both;
 }
 
 ul.pagination li {


### PR DESCRIPTION
When there are less than 5 items pagination floats up into the items.
