### PR TITLE
fix crash on nil recommendation object

### DIFF
--- a/app/controllers/recommendations_controller.rb
+++ b/app/controllers/recommendations_controller.rb
@@ -30,16 +30,19 @@ class RecommendationsController < ApplicationController
         r = current_user.recommendation
         @status_categories = ["currently_watching", "plan_to_watch", "completed"]
         @recommendations = {}
-        @status_categories.each do |cat|
-          @recommendations[cat] = Anime.where(id: r.by_status[cat])
-        end
-
         @genre_recommendations = {}
-        current_user.favorite_genres.each do |genre|
-          @genre_recommendations[ genre.slug ] = Anime.where(id: r.by_genre[genre.slug])
-        end
+        
+        unless r.nil?
+          @status_categories.each do |cat|
+            @recommendations[cat] = Anime.where(id: r.by_status[cat])
+          end
+          
+          current_user.favorite_genres.each do |genre|
+            @genre_recommendations[ genre.slug ] = Anime.where(id: r.by_genre[genre.slug])
+          end
 
-        @neon_alley = Anime.where(id: r.by_service['neon_alley'])
+          @neon_alley = Anime.where(id: r.by_service['neon_alley'])
+        end
 
         # View convenience variables. Move to translations later.
         @word_before = {


### PR DESCRIPTION
There is currently a 500 error when a brand new user account visits the `/recommendations` page, as the `#index` method attempts to do operations on `current_user.recommendation` which at that time is being created by a background worker.
