### PR TITLE
Allow 0 as rating value in APIv1

### DIFF
--- a/app/api/api_v1.rb
+++ b/app/api/api_v1.rb
@@ -451,10 +451,11 @@ class API_v1 < Grape::API
 
       # Update rating.
       if params[:rating]
-        if library_entry.rating == params[:rating].to_f
+        rating = params[:rating].to_f
+        if library_entry.rating == rating or rating == 0
           library_entry.rating = nil
         else
-          library_entry.rating = [ [0, params[:rating].to_f].max, 5].min
+          library_entry.rating = [ [0, rating].max, 5].min
         end
         result = result and library_entry.save
       end


### PR DESCRIPTION
The description of `rating` parameter says:

> To remove the rating, set this to the same value as the current rating.

Currently if you try to set the `rating` to `0`, the method returns a `201 Created` response with `false` as its body, probably because it fails [this check](https://github.com/hummingbird-me/hummingbird/blob/master/app/models/library_entry.rb#L39).

This change allows setting `rating` to `0` in order to remove the current rating. It should be backwards compatible, as using the current value to remove the rating is still possible.

The only side effect I can think of is that if one sets the `rating` to an invalid value such as `qwerty`, it will be interpreted as `0.0`. After the change, this will cause the current rating to be removed. However, I don't think this is going to be an issue.
