### PR TITLE
Fix simple ratings not showing

### DIFF
--- a/app/assets/javascripts/lib/awesome_rating.js
+++ b/app/assets/javascripts/lib/awesome_rating.js
@@ -47,7 +47,7 @@ var renderStars = function(rating) {
 
 $.fn.AwesomeRating = function(options) {
   return this.each(function() {
-    var _results;
+    var _results = [];
     var widget = this,
       rating = options["rating"];
     $(widget).empty();


### PR DESCRIPTION
This fixes issue #98.

Wasn't rendering due to attempting to `.push()` on `_results`
