### PR TITLE
Made Anime title in search results dropdown link to anime page

### DIFF
--- a/app/assets/javascripts/templates/header/search.hbs
+++ b/app/assets/javascripts/templates/header/search.hbs
@@ -10,14 +10,12 @@
     <ul class="search-dropdown">
       {{#each result in instantSearchResults}}
         <li class="search-result">
-          <a {{bind-attr href="result.link" title="result.title"}}>
             <div class="search-result-thumb">
-              <img {{bind-attr src="result.image"}} />
+                <img {{bind-attr src="result.image"}} />
             </div>
-            <div class="search-result-title">{{result.title}}</div>
+            <div class="search-result-title"><a {{bind-attr href="result.link" title="result.title"}}>{{result.title}}</a></div>
             <span {{bind-attr class=":search-result-badge :badge result.type"}}>{{result.type}}</span>
             <div class="search-result-break"></div>
-          </a>
         </li>
       {{/each}}
       {{!--


### PR DESCRIPTION
If there was some reason the HTML was structured the way it was previously feel free to close the PR. But this brings the search result dropdown menus behaviour more into line with what I would expect it to do (Clicking on the anime takes you to the anime page). 
