### PR TITLE
Remove the 'z-index' for '.login-register-card input.login-input'.

### DIFF
--- a/public/old-application.css
+++ b/public/old-application.css
@@ -19576,7 +19576,6 @@ body .ui-tooltip {
   height: 46px;
   padding: 6px 0 2px 0px;
   position: absolute;
-  z-index: 10001;
   -webkit-box-shadow: none;
   -o-box-shadow: none;
   -ms-box-shadow: none;


### PR DESCRIPTION
This fixes #81.
I don't think the `z-index` was needed for anything specific and I couldn't find any issues that that were created by removing it.
