### PR TITLE
Fix fullscreen video issue on Chrome/IE

### DIFF
--- a/app/assets/stylesheets/modules/anime-page.css.scss
+++ b/app/assets/stylesheets/modules/anime-page.css.scss
@@ -616,6 +616,11 @@ p img {
       position: relative;
       border-radius: 3px;
       border: 5px solid #23272d;
+
+      &:fullscreen {
+        max-width: 100%;
+        border: 0;
+      }
     }
   }
   .review-title {


### PR DESCRIPTION
Example of this bug in action: 

![](http://i.imgur.com/j1XS32E.png)

Also, Summernote seems to only add the `allowfullscreen` tag to Vimeo, and Youku embeds -- and they don't seem to have any configuration to change it. We may want to amend the `review_helper.rb` file to force-add it?
