### PR TITLE
force allowfullscreen attribute onto review iframes

### DIFF
--- a/app/helpers/reviews_helper.rb
+++ b/app/helpers/reviews_helper.rb
@@ -89,7 +89,9 @@ module ReviewsHelper
     noko = Nokogiri::HTML.fragment(html)
 
     # Wrap youtube videos.
-    noko.css('iframe').each {|x| x.swap("<div class='youtube-frame'>#{x}</div>") }
+    noko.css('iframe').attr('allowfullscreen', '').each { |x| 
+      x.swap("<div class='youtube-frame'>#{x}</div>")
+    }
     noko.css('.youtube-frame').each {|node| node.add_child('<div class="youtube-background"></div>') }
 
     noko.to_html


### PR DESCRIPTION
Mentioned this issue in PR https://github.com/hummingbird-me/hummingbird/pull/126

> Also, Summernote seems to only add the allowfullscreen tag to Vimeo, and Youku embeds -- and they don't seem to have any configuration to change it. We may want to amend the review_helper.rb file to force-add it?
