### PR TITLE
Fix breakdown-icon overlap

### DIFF
--- a/app/assets/stylesheets/modules/activity-feed.css.scss
+++ b/app/assets/stylesheets/modules/activity-feed.css.scss
@@ -261,7 +261,7 @@
   }
   .breakdown-icon {
     display: inline-block;
-    padding-right: 15px;
+    min-width: 60px;
     i {
       color: #686868;
       font-size: 2.8em;


### PR DESCRIPTION
Fixes breakdown-icon overlapping breakdown-time on smaller screen sizes.
