### PR TITLE
Remove all last remnants of Neon Alley integration

### DIFF
--- a/app/assets/javascripts/old/handlebars_helpers.js.coffee
+++ b/app/assets/javascripts/old/handlebars_helpers.js.coffee
@@ -36,9 +36,6 @@ Handlebars.registerHelper 'watchlistStatusChangeStory', (user, new_status) ->
 
 Handlebars.registerHelper 'watchedEpisodeStory', (user, episode_number, service) ->
   extra = ""
-  #if service
-  #  if service == "neon_alley"
-  #    extra = " on <a href='http://neonalley.com/' target='_blank'>Neon Alley</a>"
 
   user = "<a href='" + user.url + "'>" + user.name + "</a>"
   number = episode_number

--- a/app/controllers/recommendations_controller.rb
+++ b/app/controllers/recommendations_controller.rb
@@ -40,8 +40,6 @@ class RecommendationsController < ApplicationController
           current_user.favorite_genres.each do |genre|
             @genre_recommendations[ genre.slug ] = Anime.where(id: r.by_genre[genre.slug])
           end
-
-          @neon_alley = Anime.where(id: r.by_service['neon_alley'])
         end
 
         # View convenience variables. Move to translations later.

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -190,15 +190,6 @@ class UsersController < ApplicationController
   def toggle_connection
     authenticate_user!
 
-    if params[:connection] == "neonalley"
-      if params[:enable]
-        current_user.neon_alley_integration = true
-      elsif params[:disable]
-        current_user.neon_alley_integration = false
-      end
-      current_user.save
-    end
-
     respond_to do |format|
       format.html { redirect_to :back }
     end

--- a/app/models/anime.rb
+++ b/app/models/anime.rb
@@ -263,10 +263,6 @@ class Anime < ActiveRecord::Base
     Rails.cache.write("anime_poster_image_thumb:#{self.id}", self.poster_image.url(:large))
   end
 
-  def self.neon_alley_ids
-    [11, 12, 244, 412, 777, 1376, 1377, 1445, 1555, 2245, 3817, 4989, 5044, 5187, 5940, 5953, 6028, 6084, 6477, 6590, 6614, 7753]
-  end
-
   def similar(limit=20, options={})
     # FIXME
     return [] if Rails.env.development?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,7 +43,6 @@
 #  title_language_preference   :string(255)      default("canonical")
 #  followers_count_hack        :integer          default(0)
 #  following_count             :integer          default(0)
-#  neon_alley_integration      :boolean          default(FALSE)
 #  ninja_banned                :boolean          default(FALSE)
 #  last_library_update         :datetime
 #  last_recommendations_update :datetime

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -86,48 +86,6 @@
 
       .row
         .large-12.columns#connection-settings
-          -# .large-12.columns.neon-alley.facebook-connect
-          -#   .large-10.columns.no-padding
-          -#     .large-1.columns.no-padding
-          -#       = image_tag "https://si0.twimg.com/profile_images/2344625017/j467pvyrkn9317tpwr1e_bigger.jpeg", :class => "connect-icon"
-          -#     .large-11.columns
-          -#       %h4 Neon Alley
-          -#       %p Receive personalized recommendations and sync Activity Feed.
-          -#   .large-2.columns.no-padding{:style => "margin-top: 20px;"}
-          -#     - if current_user.neon_alley_integration?
-          -#       %a.button.padded.na-disconnect Disconnect
-          -#     - else
-          -#       %a.button.padded.na-connect Connect
-
-          -#   :coffee
-          -#     path = #{user_toggle_connection_path(current_user).inspect}
-
-          -#     addButtonLoader = (selector) ->
-          -#       selector.html $("<i class='fa fa-spin fa-spinner'></i>")
-              
-          -#     connect_na = ->
-          -#       addButtonLoader $("a.na-connect")
-          -#       $.ajax path,
-          -#         method: 'post'
-          -#         data:
-          -#           connection: 'neonalley'
-          -#           enable: true
-          -#         success: ->
-          -#           $("a.na-connect").removeClass("na-connect").addClass("na-disconnect").html("Disconnect").click disconnect_na
-              
-          -#     disconnect_na = ->
-          -#       addButtonLoader $("a.na-disconnect")
-          -#       $.ajax path,
-          -#         method: 'post'
-          -#         data:
-          -#           connection: 'neonalley'
-          -#           disable: true
-          -#         success: ->
-          -#           $("a.na-disconnect").removeClass("na-disconnect").addClass("na-connect").html("Connect").click connect_na
-
-          -#     $("a.na-disconnect").click disconnect_na
-          -#     $("a.na-connect").click connect_na
-
           .large-12.columns.facebook-connect
             .large-8.columns
               %a(name="facebook_connect")

--- a/app/views/home/_onboarding.html.haml
+++ b/app/views/home/_onboarding.html.haml
@@ -62,15 +62,6 @@
                 %a.button
                   %span
                     IMPORT ACCOUNT
-                
-      .large-6.columns.center.na-connect
-        = image_tag "na-connect.jpg"
-        %p.na-description Receive personalized recommendations and sync with your Activity Feed! Don't have Neon Alley? <a href="http://www.neonalley.com" target="_blank">Learn More!</a>
-        .large-12.columns
-          - if current_user.neon_alley_integration?
-            %a.button.padded.na-disconnect DISCONNECT NEON ALLEY
-          - else
-            %a.button.padded.na-connect CONNECT NEON ALLEY
 
   .completed.step
     %h2.lead Whew... You're finished!
@@ -179,34 +170,8 @@
       ).error ->
         alert "Something went wrong, couldn't import your anime list."
 
-  # Neon Alley Connect.
-  path = #{user_toggle_connection_path(current_user).inspect}
-
   addButtonLoader = (selector) ->
     selector.html $("<i class='fa fa-spin fa-spinner'></i>")
-  
-  connect_na = ->
-    addButtonLoader $("a.na-connect")
-    $.ajax path,
-      method: 'post'
-      data:
-        connection: 'neonalley'
-        enable: true
-      success: ->
-        $("a.na-connect").removeClass("na-connect").addClass("na-disconnect").html("DISCONNECT NEON ALLEY").click disconnect_na
-  
-  disconnect_na = ->
-    addButtonLoader $("a.na-disconnect")
-    $.ajax path,
-      method: 'post'
-      data:
-        connection: 'neonalley'
-        disable: true
-      success: ->
-        $("a.na-disconnect").removeClass("na-disconnect").addClass("na-connect").html("CONNECT NEON ALLEY").click connect_na
-
-  $("a.na-disconnect").click disconnect_na
-  $("a.na-connect").click connect_na
   
   # Check MAL import status.
   checkImportProgress = ->

--- a/app/views/recommendations/index.html.haml
+++ b/app/views/recommendations/index.html.haml
@@ -30,28 +30,6 @@
           checkForCompletion();
 
       - else
-        / Neon Alley Recommendations
-        - if current_user.neon_alley_integration?
-          .large-12.columns.panel.no-padding.rounded-panel
-            .large-12.columns.panel-head
-              %p.head-title Anime you'll love on <strong>Neon Alley</strong>
-              - if false
-                %p.head-action= link_to "view more", "#"
-            %hr.block-divider
-            - if @neon_alley.length == 0
-              %h5.default-state.center Uh oh, we don't have any recommendations for you yet!
-            - else
-              %ul.small-block-grid-2.large-block-grid-5.single-recs
-                - @neon_alley[0..4].each do |anime|
-                  %li.single-rec
-                    .rec-thumbnail
-                      %p.wanna-watch
-                        %a.small.button{:"data-slug" => anime.slug}
-                          Plan to Watch
-                      = link_to (image_tag anime.poster_image(:large), alt: anime.canonical_title(current_user.title_language_preference)), anime
-                    %p.title= anime.canonical_title(current_user.title_language_preference)
-                    %a.not-interested(href="javascript:void(0)"){:"data-slug" => anime.slug} Not Interested
-
         / By status recommendations
         - @status_categories.each do |category|
           .large-12.columns.panel.no-padding.rounded-panel
@@ -117,16 +95,6 @@
               = link_to "Plan to Watch", "#"
             %li
               = link_to "Completed", "#"
-
-      - if current_user.neon_alley_integration?
-        .large-12.columns.panel.no-padding.rounded-panel
-          .large-12.columns.panel-head
-            %p.head-title By Service
-            %p.head-action= link_to "edit", "#"
-          %hr.block-divider
-            %ul.filter-options
-              %li
-                = link_to "Neon Alley", "#"
 
       .large-12.columns.panel.no-padding.rounded-panel
         .large-12.columns.panel-head

--- a/app/workers/recommending_worker.rb
+++ b/app/workers/recommending_worker.rb
@@ -82,7 +82,6 @@ class RecommendingWorker
         completed: []
       },
       by_service: {
-        neon_alley: []
       },
       by_genre: {
       }
@@ -115,13 +114,6 @@ class RecommendingWorker
     general.each do |sid|
       genre_ids[sid] ||= anime[sid].genre_ids
       halt = true
-
-      if recommendations[:by_service][:neon_alley].length < 10
-        halt = false
-        if Anime.neon_alley_ids.include? sid
-          recommendations[:by_service][:neon_alley].push sid
-        end
-      end
 
       favorite_genres.each do |genre|
         if recommendations[:by_genre][genre.slug].length < 10

--- a/db/migrate/20140707100609_remove_neon_alley.rb
+++ b/db/migrate/20140707100609_remove_neon_alley.rb
@@ -1,0 +1,5 @@
+class RemoveNeonAlley < ActiveRecord::Migration
+  def change
+    remove_column :users, :neon_alley_integration
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1313,7 +1313,6 @@ CREATE TABLE users (
     title_language_preference character varying(255) DEFAULT 'canonical'::character varying,
     followers_count_hack integer DEFAULT 0,
     following_count integer DEFAULT 0,
-    neon_alley_integration boolean DEFAULT false,
     ninja_banned boolean DEFAULT false,
     last_library_update timestamp without time zone,
     last_recommendations_update timestamp without time zone,
@@ -3107,4 +3106,6 @@ INSERT INTO schema_migrations (version) VALUES ('20140629091741');
 INSERT INTO schema_migrations (version) VALUES ('20140630020533');
 
 INSERT INTO schema_migrations (version) VALUES ('20140630031803');
+
+INSERT INTO schema_migrations (version) VALUES ('20140707100609');
 

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -43,7 +43,6 @@
 #  title_language_preference   :string(255)      default("canonical")
 #  followers_count_hack        :integer          default(0)
 #  following_count             :integer          default(0)
-#  neon_alley_integration      :boolean          default(FALSE)
 #  ninja_banned                :boolean          default(FALSE)
 #  last_library_update         :datetime
 #  last_recommendations_update :datetime
@@ -101,7 +100,6 @@ vikhyat:
   title_language_preference: canonical
   followers_count_hack: 1039
   following_count: 988
-  neon_alley_integration: false
   ninja_banned: false
   last_library_update: 2013-12-30 03:17:37.271880000 Z
   last_recommendations_update: 2013-12-05 05:41:16.855258000 Z
@@ -151,7 +149,6 @@ josh:
   title_language_preference: canonical
   followers_count_hack: 656
   following_count: 342
-  neon_alley_integration: true
   ninja_banned: false
   last_library_update: 2013-09-22 19:37:18.851425000 Z
   last_recommendations_update: 2013-09-17 04:56:06.391249000 Z

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -43,7 +43,6 @@
 #  title_language_preference   :string(255)      default("canonical")
 #  followers_count_hack        :integer          default(0)
 #  following_count             :integer          default(0)
-#  neon_alley_integration      :boolean          default(FALSE)
 #  ninja_banned                :boolean          default(FALSE)
 #  last_library_update         :datetime
 #  last_recommendations_update :datetime


### PR DESCRIPTION
I grepped the codebase for "neon" and attempted to tear out everything related to the old neon alley integration.  This should be pretty much everything.

Large portions were commented out or in files which don't seem to be used anymore, but I removed it anyways because it's basically 5 keystrokes in vim.

Also I _hope_ I didn't cause the recommendations worker to explode (it shouldn't in theory, but that thing is a pile of spaghetti)
