### PR TITLE
Fix loading paginated content on IE

### DIFF
--- a/app/assets/javascripts/components/load-more.js
+++ b/app/assets/javascripts/components/load-more.js
@@ -1,7 +1,7 @@
 Hummingbird.LoadMoreComponent = Ember.Component.extend({
   checkInView: function() {
     var elementBottom = this.$().offset().top + this.$().height(),
-        windowBottom = window.scrollY + Ember.$(window).height();
+        windowBottom = window.pageYOffset + Ember.$(window).height();
     if (elementBottom < windowBottom + 200) {
       this.sendAction();
     }

--- a/app/assets/javascripts/controllers/story_controller.js
+++ b/app/assets/javascripts/controllers/story_controller.js
@@ -21,7 +21,7 @@ Hummingbird.StoryController = Ember.ObjectController.extend(Hummingbird.HasCurre
   }.property('model.poster'),
 
   mediaRoute: function () {
-    if (this.get('model.media').constructor.toString() === "Hummingbird.Anime") {
+    if (this.get('mediaStory') && this.get('model.media').constructor.toString() === "Hummingbird.Anime") {
       return 'anime';
     }
   }.property('model.media'),


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/window.scrollY

> window.pageYOffset == window.scrollY; // always true
> For cross-browser compatibility, use window.pageYOffset instead of window.scrollY.

Will fix #148

---

The other change is a fix to [Ember Inspector](https://github.com/emberjs/ember-inspector), as it was throwing an error when attempting to inspect a `StoryController` of a `comment` type
