### PR TITLE
Fix overflow blocking tooltip

### DIFF
--- a/app/assets/stylesheets/modules/anime-page.css.scss
+++ b/app/assets/stylesheets/modules/anime-page.css.scss
@@ -213,7 +213,6 @@ h4.series-title {
   background: #fff;
   border-left: 1px solid #ddd;
   border-top-right-radius: 4px;
-  overflow: hidden;
   @media (min-width: 768px) {
     min-height: 1000px;
   }


### PR DESCRIPTION
Issue [#153](https://github.com/hummingbird-me/hummingbird/issues/153)

> The `overflow: hidden` property on `.series-content` causes the alternate title tooltip to clip when the canonical title is nearly as wide as the series content box.
> 
> Examples:
> 1 http://hummingbird.me/anime/otome-wa-boku-ni-koishiteru-futari-no-elder
> 2 http://hummingbird.me/anime/ginga-eiyuu-densetsu-gaiden-rasen-meikyuu
> 
> Reference: http://forums.hummingbird.me/t/alternate-title-overlapped/11827
