### PR TITLE
Fixed incorrect First Impressions label for reviews section on entries without a finish date

### DIFF
--- a/app/assets/javascripts/models/anime.js
+++ b/app/assets/javascripts/models/anime.js
@@ -63,6 +63,8 @@ Hummingbird.Anime = DS.Model.extend({
   }.property('startedAiring', 'finishedAiring', 'episodeCount'),
 
   notYetAired: Ember.computed.equal('airingStatus', 'Not Yet Aired'),
+  
+  completedAiring: Ember.computed.equal('airingStatus', 'Finished Airing'),
 
   formattedAirDates: function() {
     var format, formattedFinishedAiring, formattedStartedAiring, result;

--- a/app/assets/javascripts/templates/anime/index.emblem
+++ b/app/assets/javascripts/templates/anime/index.emblem
@@ -61,7 +61,7 @@ h1.series-title.hidden-xs
 
 unless notYetAired
   .review-listing
-    if finishedAiring
+    if completedAiring
       h4
         | Trending Reviews
         link-to 'reviews.index' classNames="btn btn-xs btn-default pull-right" | view all


### PR DESCRIPTION
bug report and explanation of fix here: http://forums.hummingbird.me/t/incorrect-first-impressions-label-for-reviews-section-on-entries-without-a-finish-date/12895/
