### PR TITLE
Handle short youtube links in message formatter.

### DIFF
--- a/app/services/message_formatter.rb
+++ b/app/services/message_formatter.rb
@@ -72,8 +72,8 @@ class MessageFormatter
   end
 
   def embeddable_video_code(link)
-    return unless link =~ /(?:http:\/\/)?(?:www\.)?(?:youtube\.com|youtu\.be)\/(?:watch\?v=)?(.+)/
-    link.scan(/v=([A-Za-z0-9\-_]+)/)[0][0]
+    return unless match_data = /(?:http:\/\/)?(?:www\.)?(?:youtube\.com|youtu\.be)\/(?:watch\?v=)?(.+)/.match(link)
+    match_data[1]
   rescue
     nil
   end

--- a/test/services/message_formatter_test.rb
+++ b/test/services/message_formatter_test.rb
@@ -33,7 +33,17 @@ class MessageFormatterTest < ActiveSupport::TestCase
   end
 
   test "embeds youtube videos" do
-    assert_match /iframe/, format("https://www.youtube.com/watch?v=v8YEw6JaM3c")
+    format = format("https://www.youtube.com/watch?v=v8YEw6JaM3c")
+
+    assert_match /iframe/, format
+    assert_match /http:\/\/youtube.com\/embed\/v8YEw6JaM3c/, format
+  end
+
+  test "embeds youtube videos with short link" do
+    format = format("http://youtu.be/v8YEw6JaM3c")
+
+    assert_match /iframe/, format
+    assert_match /http:\/\/youtube.com\/embed\/v8YEw6JaM3c/, format
   end
 
   test "removes original embedded link URL" do


### PR DESCRIPTION
Fixes http://forums.hummingbird.me/t/embed-youtu-be-share-links-into-activity-feed/12203

We don't need that `scan` since we're matching video id in the main regexp.
