### PR TITLE
dont preload empty data

### DIFF
--- a/app/assets/javascripts/lib/preload_store.js
+++ b/app/assets/javascripts/lib/preload_store.js
@@ -15,7 +15,7 @@ Hummingbird.PreloadStore = {
 
   popEmberData: function(key, path, object, store, edQuery) {
     var data = Hummingbird.PreloadStore.pop(key);
-    if (typeof data === "undefined") {
+    if (typeof data === "undefined" || data === null) {
       if (typeof edQuery !== "undefined") {
         return edQuery();
       } else {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,12 +8,14 @@ class ApplicationController < ActionController::Base
   # Ember Data's cache.
   def preload_to_ember!(data, options={})
     @preload ||= []
-    @preload << ed_serialize(data, options)
+    data = ed_serialize(data, options)
+    @preload << data unless data.nil?
   end
 
   def ed_serialize(data, options={})
     data = data.to_a if data.respond_to? :to_ary
     data = [data] unless data.is_a? Array
+    return if data.empty?
     options[:scope] = current_user
     options[:root] ||= data.first.class.to_s.underscore.pluralize
     options[:each_serializer] = options[:serializer] if options[:serializer]


### PR DESCRIPTION
Currently when a user doesn't have library entries or stories, the client-side preload fails as the dump is as following:

Master:

`window.genericPreload = {"blotter":null,"recent_library_entries":{"nil_classes":[]},"dashboard_timeline":{"nil_classes":[]}};`

PR:

`window.genericPreload = {"blotter":null,"recent_library_entries":null,"dashboard_timeline":null};`
