### PR TITLE
Fixed line-height style not applying to search icon

### DIFF
--- a/app/assets/stylesheets/base/layout.css.scss
+++ b/app/assets/stylesheets/base/layout.css.scss
@@ -311,8 +311,10 @@ html { overflow-y: scroll; }
       text-align: center;
       width: 50px;
       padding: 15px;
+      line-height: 20px;
       @media (max-width: 768px) {
         padding: 0px;
+        line-height: 50px;
       }
 
       .fa {


### PR DESCRIPTION
The line-height style that applies to the nav bar uses .navbar-nav>li>a . However, the html for the search icon is structured .navbar-nav>li>div>a . This causes the search icon to appear lower compared to the notification bell and for the element footprint to overflow the nav bar.
![screenshot 2014-08-01 17 36 09](https://cloud.githubusercontent.com/assets/2680117/3785438/58245dee-19c4-11e4-87b6-95506adc2358.png)
