### PR TITLE
fixed missing </div> in manga library causing nesting issues

### DIFF
--- a/app/assets/javascripts/templates/user/manga_library.hbs
+++ b/app/assets/javascripts/templates/user/manga_library.hbs
@@ -24,6 +24,7 @@
                   {{#each section in sections}}
                     <button {{action "showSection" section}} {{bind-attr class=":btn :btn-default section.displayVisible:active"}}> {{section.title}}</button>
                   {{/each}}
+                </div>
                 <div class="library-section-select hidden-md hidden-lg">
                   <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
                     {{showSection}} <i class="fa fa-caret-down"></i>


### PR DESCRIPTION
This was done to in the anime library here edae9be4eea0717f2c5ccd253c9a09df2d9cbdd2. This completes the fix, of nesting issue introduced during .emblem to .hbs conversion, started with #207
