### PR TITLE
Fixed unbroken strings of text overflowing comments

### DIFF
--- a/app/assets/stylesheets/partials/status-panel.css.scss
+++ b/app/assets/stylesheets/partials/status-panel.css.scss
@@ -305,6 +305,8 @@
 
     p {
       margin: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
   }
 


### PR DESCRIPTION
Fix bug reported [here](http://forums.hummingbird.me/t/post-replies-stretch-infinitely/13764). Used technique applied to main posts already of overflow: hidden and text-overflow: ellipsis
