### PR TITLE
Auto embed if there are multiple links

### DIFF
--- a/app/services/message_formatter.rb
+++ b/app/services/message_formatter.rb
@@ -46,7 +46,7 @@ class MessageFormatter
     links = noko.css('a').map {|link| link['href'] }
 
     # Only do autoembedding if there is exactly one embeddable link.
-    embeddable_links = links.select{|link| embeddable_image?(link) || embeddable_video_code != nil}
+    embeddable_links = links.select{|link| embeddable_image?(link) || embeddable_video_code(link) != nil}
     return if embeddable_links.length != 1
     link = embeddable_links.first
 


### PR DESCRIPTION
Auto embed if there is only a single embeddable link, instead of if there is only one link regardless of if it's embeddable. I haven't tested this, but it Should Work™

Saw someone complain about this today and I came across it reading through the source.
