### PR TITLE
Fixed old ad units causing spacing issues

### DIFF
--- a/app/assets/javascripts/templates/user/followers.hbs
+++ b/app/assets/javascripts/templates/user/followers.hbs
@@ -1,9 +1,3 @@
-<div class="profile-leaderboard">
-  <div class="ad">
-    {{ad-unit adId="1293413" adClass="257f81e798bd68dd81e60f42838f361f"}}
-  </div>
-</div>
-
 <div class="container">
   {{#each}}
     <div class="follow-panel-wrapper">

--- a/app/assets/javascripts/templates/user/following.hbs
+++ b/app/assets/javascripts/templates/user/following.hbs
@@ -1,9 +1,3 @@
-<div class="profile-leaderboard">
-  <div class="ad">
-    {{ad-unit adId="1293413" adClass="257f81e798bd68dd81e60f42838f361f"}}
-  </div>
-</div>
-
 <div class="container">
   {{#each}}
     <div class="follow-panel-wrapper">


### PR DESCRIPTION
With the new ad unit in templates/user.hbs, these are no longer necessary. They aren't displaying but creating extra space on the followers and following pages.

**before**
![screenshot 2014-08-09 15 07 05](https://cloud.githubusercontent.com/assets/2680117/3867313/f81cd99e-1ff9-11e4-8203-1d4c99ac84ed.png)

**after**
![screenshot 2014-08-09 15 17 20](https://cloud.githubusercontent.com/assets/2680117/3867320/0d535a4a-1ffa-11e4-8442-98836259b18d.png)
