### PR TITLE
Add finished_airing bool to API v2 anime metadata

### DIFF
--- a/app/controllers/api/v2/api_controller.rb
+++ b/app/controllers/api/v2/api_controller.rb
@@ -25,7 +25,8 @@ module Api::V2
         community_rating: anime.bayesian_average,
         age_rating: nfb(anime.age_rating),
         episode_count: anime.episode_count,
-        episode_length: anime.episode_length
+        episode_length: anime.episode_length,
+        finished_airing: anime.finished_airing_date.present?
       }
     end
   end


### PR DESCRIPTION
http://forums.hummingbird.me/t/a-couple-of-questions-about-the-both-api-v1-v2/13862 saw this and decided to fix it.

Not tested as I don't have a development environment atm. But as long as finished_airing_date is nil before it's finished airing and present? is in scope this should be fine. I'll update the wiki page for v2 if this is merged.

P.S. If you don't want changes to the API at this stage feel free to close this PR
