### PR TITLE
Set title attribute of anime links at quick update

### DIFF
--- a/app/assets/javascripts/templates/components/quick-update.hbs
+++ b/app/assets/javascripts/templates/components/quick-update.hbs
@@ -15,7 +15,7 @@
               <div class="overlay-wrapper">
                 <div class="overlay-panel">
                   <h4 class="series-title">
-                    {{#link-to 'anime' anime.id class="quick-update-title-link"}}
+                    {{#link-to 'anime' anime.id class="quick-update-title-link" title=anime.canonicalTitle}}
                       {{anime.canonicalTitle}}
                     {{/link-to}}
                   </h4>


### PR DESCRIPTION
So that we can see overflowing titles on hover:

![quick-update](https://cloud.githubusercontent.com/assets/1078430/4031540/4ca810d0-2c68-11e4-9443-7aeea75bca11.gif)
