### PR TITLE
Alternative "online" indicator

### DIFF
--- a/app/assets/stylesheets/partials/user-cover-image.css.scss
+++ b/app/assets/stylesheets/partials/user-cover-image.css.scss
@@ -58,8 +58,8 @@
 
     .online-box {
       background: rgba(0,0,0,.3);
-      width: 20px;
-      height: 20px;
+      width: 100%;
+      height: 2px;
       position: absolute;
       bottom: 0;
       right: 0;
@@ -68,15 +68,15 @@
 
       .online-indicator {
         position: absolute;
-        width: 10px;
-        height: 10px;
-        border-radius: 100px;
-        bottom: 4px;
-        right: 5px;
-        border: 1px solid #333;
+        width: 100%;
+        height: 1px;
+        /*border-radius: 100px;*/
+        bottom: 0px;
+        right: 0px;
+        /*border: 1px solid #333;*/
         z-index: 1;
 
-        &.online { background: #58e08e; }
+        &.online { background: #58e08e; box-shadow: 0px 0px 5px 0px rgb(88, 224, 142); }
         &.offline { background: #afafaf; }
       }
     }


### PR DESCRIPTION
Well, I've always thought that the _online_ indicator looked a little, uh, _tacky_ (maybe). I don't think it quite fitted in with the overall look of HB. So just throwing a potential design:

<img src="http://a.pomf.se/fzcylf.png"/>

<img src="http://a.pomf.se/aacocp.png">

I suppose it looks a little ugly since the avatar has a border radius... >.<
