### PR TITLE
Fix dropdown menus on anime pages being hidden

### DIFF
--- a/app/assets/stylesheets/partials/anime-page.css.scss
+++ b/app/assets/stylesheets/partials/anime-page.css.scss
@@ -4,7 +4,6 @@
   background: #4b5360;
   position: relative;
   padding: 30px 0;
-  overflow: hidden;
   .container {
     padding-right: 0;
     @media (max-width: 768px) {


### PR DESCRIPTION
It was initially reported here: https://forums.hummingbird.me/t/add-to-library-menu-on-reviews-not-showing-correctly/15465
