### PR TITLE
Added updating of last_library_update upon entry deletion

### DIFF
--- a/app/models/library_entry.rb
+++ b/app/models/library_entry.rb
@@ -125,6 +125,9 @@ class LibraryEntry < ActiveRecord::Base
 
     # Update user's life spent on anime.
     self.user.update_life_spent_on_anime( - self.episodes_watched * (self.anime.episode_length || 0) )
+    
+    # Update the user's `last_library_update` time.
+    self.user.update_column :last_library_update, Time.now
   end
 
   ALLOWED_IN_IMPORT = [:episodes_watched, :rewatch_count, :rewatching, :notes, :status, :private,


### PR DESCRIPTION
Case where this is useful is when last_library_update is used to fetch entries, and during the fetching all local entries not in the response are deleted.
