### PR TITLE
layout html overflow-y auto, rebased

### DIFF
--- a/app/assets/stylesheets/base/layout.css.scss
+++ b/app/assets/stylesheets/base/layout.css.scss
@@ -1,4 +1,4 @@
-html { overflow-y: scroll; }
+html { overflow-y: auto; }
 
 /* Development Styles */
 .profiler-results {


### PR DESCRIPTION
Changing behaviour of clipping top/bottom edges of the html block to
auto, thus only adding Y axis scroll bar when needed.
