### PR TITLE
Add airing dates to APIv1

### DIFF
--- a/app/api/api_v1.rb
+++ b/app/api/api_v1.rb
@@ -95,7 +95,9 @@ class API_v1 < Grape::API
           episode_count: anime.episode_count,
           cover_image: anime.poster_image_thumb,
           synopsis: anime.synopsis,
-          show_type: anime.show_type
+          show_type: anime.show_type,
+          started_airing: anime.started_airing_date,
+          finished_airing: anime.finished_airing_date
         }
         if include_genres
           json[:genres] = anime.genres.map {|x| {name: x.name} }


### PR DESCRIPTION
About a year ago, @vikhyat [said](http://forums.hummingbird.me/t/questions-to-apiv2/1829/9):

> I intend to reduce the amount of information returned by the library API call. With the way things are right now the response size for large lists is too large, and mostly full of anime information most of which is not needed to display the library.

Is this still a concern? If not, we should "totally add fields without breaking anything", as the wise @NuckChorris once said.

This PR currently adds the most requested fields, namely `started_airing` and `finished_airing`. But the API also misses `age_rating`, `community_rating` and `episode_length`. For watchlists and search results, `genres` is missing too, because `include_genres` parameter is set to `false`.
