### PR TITLE
Add age_rating, community_rating and episode_length to APIv1

### DIFF
--- a/app/api/api_v1.rb
+++ b/app/api/api_v1.rb
@@ -93,11 +93,14 @@ class API_v1 < Grape::API
           title: anime.canonical_title(title_language_preference),
           alternate_title: anime.alternate_title(title_language_preference),
           episode_count: anime.episode_count,
+          episode_length: anime.episode_length,
           cover_image: anime.poster_image_thumb,
           synopsis: anime.synopsis,
           show_type: anime.show_type,
           started_airing: anime.started_airing_date,
-          finished_airing: anime.finished_airing_date
+          finished_airing: anime.finished_airing_date,
+          community_rating: anime.bayesian_average,
+          age_rating: anime.age_rating.blank? ? nil : anime.age_rating
         }
         if include_genres
           json[:genres] = anime.genres.map {|x| {name: x.name} }


### PR DESCRIPTION
Following up on #261. With this, the remaining differences between `present_anime` methods are as following:
- v1 provides `status`, where v2 expects the client to calculate it from airing dates. Not an issue.
- v1 provides `url`, where v2 expects the client to put `https://hummingbird.me/anime/` and `slug` together. Not an issue, obviously.
- v1 has `title` and `alternate_title`, where v2 has `canonical_title`, `english_title` and `romaji_title`. As far as I'm aware, they end up transferring the same amount of information.
- v2 has `screencaps` and `youtube_trailer_id`. Not an issue, personally.

In other words, this is about as good as it gets without breaking backwards compatibility.
