### PR TITLE
Fixed gradient blur for Firefox

### DIFF
--- a/app/assets/javascripts/templates/user.hbs
+++ b/app/assets/javascripts/templates/user.hbs
@@ -14,18 +14,16 @@
       <div class="cover-overlay" {{bind-attr style=coverImageStyle}}></div>
     </div>
     <svg height="0">
-    <defs>
-      <mask id="mask-linear">
-        <rect width="400" height="300"></rect>
-        <linearGradient id="l1" x1="0" y1="0" x2="0" y2="1">
-          <stop stop-color="black" offset="0%"></stop>
-          <stop stop-color="white" offset="100%"></stop>
-        </linearGradient>
-      </mask>
-      <filter id="filtre">
-        <feGaussianBlur in="SourceGraphic" stdDeviation="3"></feGaussianBlur>
+      <filter id="blur">
+        <feGaussianBlur stdDeviation="3"/>
       </filter>
-    </defs>
+      <mask id="blur-fade" maskUnits="objectBoundingBox" maskContentUnits="objectBoundingBox">
+        <linearGradient id="blur-gradient" gradientUnits="objectBoundingBox" x1="0" y1="0" x2="0" y2="1">
+          <stop stop-color="white" stop-opacity="0" offset="0.5"></stop>
+          <stop stop-color="white" stop-opacity="1" offset="1"></stop>
+        </linearGradient>
+        <rect x="0" y="0" width="1" height="1" fill="url(#blur-gradient)"></rect>
+      </mask>
     </svg>
   </div>
 </div>

--- a/app/assets/stylesheets/partials/user-cover-image.css.scss
+++ b/app/assets/stylesheets/partials/user-cover-image.css.scss
@@ -67,14 +67,11 @@
     background-position: center;
     height: 330px;
     width: 100%;
-    -webkit-mask: -webkit-linear-gradient(black, transparent, black);
-    -webkit-mask: linear-gradient(black, transparent, black);
+    -webkit-mask: -webkit-linear-gradient(black, transparent 30%, black);
+    -webkit-mask: linear-gradient(black, transparent 30%, black);
     -webkit-filter: blur(3px);
-    -moz-mask: -moz-linear-gradient(black, transparent, black);
-    -moz-mask: linear-gradient(black, transparent, black);
-    -moz-filter: blur(3px);
-    mask: url('#mask-linear');
-    filter: url('#filtre');
+    mask: url(#blur-fade);
+    filter: url("#blur");
   }
 }
 


### PR DESCRIPTION
Firefox only supports SVG filters and webkit/blink based browsers only supports CSS filters :(
