### PR TITLE
Fix Discourse API endpoint that broke

### DIFF
--- a/app/assets/javascripts/templates/dashboard.hbs
+++ b/app/assets/javascripts/templates/dashboard.hbs
@@ -89,7 +89,7 @@
         </div>
       </div>
 
-      {{community-widget title="Industry news" showMoreURL="https://forums.hummingbird.me/category/industry-news" apiCall="https://forums.hummingbird.me/category/industry-news.json"}}
+      {{community-widget title="Industry news" showMoreURL="https://forums.hummingbird.me/c/industry-news" apiCall="https://forums.hummingbird.me/c/industry-news.json"}}
       <div class="feed-sm-sidebar-advert">
         {{ad-unit adId="1298407" adClass="257f81e798bd68dd81e60f42838f361f"}}
       </div>


### PR DESCRIPTION
A Discourse update renamed the category endpoint causing a dashboard widget to break
