### PR TITLE
Fix header style for empty cover images

### DIFF
--- a/app/assets/javascripts/controllers/anime_controller.js
+++ b/app/assets/javascripts/controllers/anime_controller.js
@@ -1,4 +1,8 @@
 HB.AnimeController = Ember.ObjectController.extend(HB.HasCurrentUser, {
+  noCoverImage: function() {
+    return !this.get('model.coverImage');
+  }.property('model.coverImage'),
+
   coverImageStyle: function() {
     var coverImage = this.get('model.coverImage');
     if (!coverImage) { return false; }

--- a/app/assets/javascripts/templates/anime.hbs
+++ b/app/assets/javascripts/templates/anime.hbs
@@ -1,4 +1,4 @@
-<div class="series-header" {{bind-attr style=coverImageStyle}}>
+<div {{bind-attr class=":series-header noCoverImage"}} {{bind-attr style=coverImageStyle}}>
   <div class="container">
     <div class="header-buttons">
       <span class="edit-button">

--- a/app/assets/stylesheets/partials/anime-page.css.scss
+++ b/app/assets/stylesheets/partials/anime-page.css.scss
@@ -368,6 +368,16 @@
 }
 
 
+.series-header .no-cover-image {
+  .container {
+    height: 200px;
+    @media (max-width: 820px) {
+      height: 100px;
+    }
+  }
+}
+
+
 /* Condensed header shown on non-index anime pages. */
 .series-header .condensed {
   .series-title {


### PR DESCRIPTION
Anime pages without a cover image are currently making a request to `/anime/null` because of [this](https://github.com/hummingbird-me/hummingbird/blob/1f1b00e640d71ad99c5704eed92eb91237dbc4d1/app/assets/javascripts/templates/anime.hbs#L1) line:

``` html
<div class="series-header" {{bind-attr style=coverImageStyle}}>
```

``` html
<div class="series-header" style="background-image: url('null'); background-position: 50% -0px;">
```

Disclosure: I don't know Ember (or JavaScript, for that matter). Is it okay to return `null` from `coverImageStyle` function, or does it need to return `""` instead?
