### PR TITLE
Fix text color for quick update

### DIFF
--- a/app/frontend/app/templates/components/quick-update.hbs
+++ b/app/frontend/app/templates/components/quick-update.hbs
@@ -14,11 +14,11 @@
             <li {{bind-attr class=":watched-series isPTW:plan-to-watch"}}>
               <div class="overlay-wrapper">
                 <div class="overlay-panel">
-                  <h4 class="series-title">
-                    {{#link-to 'anime' anime.id class="quick-update-title-link" title=anime.displayTitle}}
+                  {{#link-to 'anime' anime.id class="quick-update-title-link" title=anime.displayTitle}}
+                    <h4 class="series-title">
                       {{anime.displayTitle}}
-                    {{/link-to}}
-                  </h4>
+                    </h4>
+                  {{/link-to}}
                   <div class="actionable">
                     {{#if loading}}
                       <a class="episode-button"><i class="fa fa-spin fa-spinner"></i></a>


### PR DESCRIPTION
The anchor element overrides the text color declared by `series-title`. This is a regression that happened a *long* time ago that always annoyed me.

![Change Preview](http://f.cl.ly/items/2u1y220N3r3n0E0U201J/Image%202015-01-06%20at%2011.03.33%20PM.png)