### PR TITLE
Switch rails console to Pry (Fixes #323)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -119,6 +119,9 @@ gem 'rubyfish' # String matching
 gem 'ruby-progressbar'
 gem 'parallel'
 
+# Pry
+gem 'pry-rails', :group => :development
+
 # Metrics
 gem 'mixpanel'
 gem 'kibana-rack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -289,6 +289,8 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry-rails (0.3.2)
+      pry (>= 0.9.10)
     qunit-rails (0.0.7)
       railties
     rack (1.5.2)
@@ -516,6 +518,7 @@ DEPENDENCIES
   pg (= 0.17.1)
   pg_search (~> 0.7)
   pghero
+  pry-rails
   qunit-rails
   rack-attack
   rack-cors


### PR DESCRIPTION
Title says it all.  Turns out all you gotta do is require the `pry-rails` gem.