### PR TITLE
Don't show user actions to guests on anime pages

### DIFF
--- a/app/frontend/app/templates/anime/index.hbs
+++ b/app/frontend/app/templates/anime/index.hbs
@@ -138,34 +138,34 @@
           </ul>
         </div>
 
-        <div {{bind-attr class=":user-actions libraryEntryExists::no-entry"}}>
-          <div class="btn-group">
+        {{#if currentUser.isSignedIn}}
+          <div {{bind-attr class=":user-actions libraryEntryExists::no-entry"}}>
+            <div class="btn-group">
 
-            <button {{bind-attr class=":library-button :library-entry :dropdown-toggle libraryStatus:active"}} type="button" data-toggle="dropdown">
-              {{#if libraryEntryExists}}
-                {{libraryEntry.status}}&nbsp;&nbsp;<i {{bind-attr class=":fa :fa-caret-down"}}></i>
-              {{else}}
-                Add to Library&nbsp;&nbsp;<i {{bind-attr class=":fa :fa-caret-down"}}></i>
-              {{/if}}
-            </button>
+              <button {{bind-attr class=":library-button :library-entry :dropdown-toggle libraryStatus:active"}} type="button" data-toggle="dropdown">
+                {{#if libraryEntryExists}}
+                  {{libraryEntry.status}}&nbsp;&nbsp;<i {{bind-attr class=":fa :fa-caret-down"}}></i>
+                {{else}}
+                  Add to Library&nbsp;&nbsp;<i {{bind-attr class=":fa :fa-caret-down"}}></i>
+                {{/if}}
+              </button>
 
-            <ul class="dropdown-menu">
-              <li><a {{action "setLibraryStatus" "Currently Watching"}}>Currently Watching</a></li>
-              <li><a {{action "setLibraryStatus" "Plan to Watch"}}>Plan to Watch</a></li>
-              <li><a {{action "setLibraryStatus" "Completed"}}>Completed</a></li>
-              <li><a {{action "setLibraryStatus" "On Hold"}}>On Hold</a></li>
-              <li><a {{action "setLibraryStatus" "Dropped"}}>Dropped</a></li>
-              <li><a {{action "removeFromLibrary"}}>Remove from Library</a></li>
-            </ul>
-          </div>
-          {{#if currentUser.isSignedIn}}
+              <ul class="dropdown-menu">
+                <li><a {{action "setLibraryStatus" "Currently Watching"}}>Currently Watching</a></li>
+                <li><a {{action "setLibraryStatus" "Plan to Watch"}}>Plan to Watch</a></li>
+                <li><a {{action "setLibraryStatus" "Completed"}}>Completed</a></li>
+                <li><a {{action "setLibraryStatus" "On Hold"}}>On Hold</a></li>
+                <li><a {{action "setLibraryStatus" "Dropped"}}>Dropped</a></li>
+                <li><a {{action "removeFromLibrary"}}>Remove from Library</a></li>
+              </ul>
+            </div>
             {{#if libraryEntryExists}}
               <div class="personal-rating active">
                 {{awesome-rating type=currentUser.ratingType editable="true" action="setLibraryRating" rating=libraryEntry.rating}}
               </div>
             {{/if}}
-          {{/if}}
-        </div>
+          </div>
+        {{/if}}
       </div>
     </div>
     <!-- End series panel -->


### PR DESCRIPTION
Star ratings are hidden for guests, but the dropdown button is still visible and just throws a connection error alert when a status is selected.

![](https://i.imgur.com/GppH0EE.png?1)

#357