### PR TITLE
Fix text displacement when there are no reviews

### DIFF
--- a/app/assets/stylesheets/partials/anime-page.css.scss
+++ b/app/assets/stylesheets/partials/anime-page.css.scss
@@ -516,6 +516,7 @@
 
     .trending-review-empty {
       text-align: center;
+      margin-top: 39px;
       margin-bottom: 35px;
       padding: 25px;
       padding-bottom: 0;

--- a/app/frontend/app/templates/anime/_trending_reviews.hbs
+++ b/app/frontend/app/templates/anime/_trending_reviews.hbs
@@ -2,8 +2,7 @@
   {{partial "media/review_summary"}}
 {{else}}
   <div class="trending-review-empty">
-    <i class="empty-icon fa fa-meh-o"></i>
-    <p>You came to us for reviews and it seems nobody has written one yet. We're going to take a cold shower to wash away the shame. In the meantime, maybe you could write the first review? The fortune and fame are yours for the taking.</p>
+    <p>It seems nobody has written a review yet. The fame and fortune are yours for the taking.</p>
     <a class="btn btn-default" {{bind-attr href=newReviewURL}}>Write the first review</a>
   </div>
 {{/each}}

--- a/app/frontend/app/templates/anime/index.hbs
+++ b/app/frontend/app/templates/anime/index.hbs
@@ -259,9 +259,11 @@
       </div>
       <div class="reviews">
         <h4> Reviews:</h4>
-        <div class="review-links">
-          <a {{bind-attr href=fullReviewsURL}}>View All</a> · <a {{bind-attr href=newReviewURL}}>Write One</a>
-        </div>
+        {{#if trendingReviews}}
+          <div class="review-links">
+            <a {{bind-attr href=fullReviewsURL}}>View All</a> · <a {{bind-attr href=newReviewURL}}>Write One</a>
+          </div>
+        {{/if}}
         {{partial "anime/trending_reviews"}}
       </div>
     </div>

--- a/app/frontend/app/templates/anime/index.hbs
+++ b/app/frontend/app/templates/anime/index.hbs
@@ -258,7 +258,7 @@
         </div>
       </div>
       <div class="reviews">
-        <h4> Reviews:</h4>
+        <h4>Reviews:</h4>
         {{#if trendingReviews}}
           <div class="review-links">
             <a {{bind-attr href=fullReviewsURL}}>View All</a> · <a {{bind-attr href=newReviewURL}}>Write One</a>

--- a/app/frontend/app/templates/reviews/index.hbs
+++ b/app/frontend/app/templates/reviews/index.hbs
@@ -17,7 +17,7 @@
     {{#unless canLoadMore}}
       <div class="trending-review-empty">
         <i class="empty-icon fa fa-meh-o"></i>
-        <h4> Well, this is pretty awkward.</h4>
+        <h4>Well, this is pretty awkward.</h4>
         <p>
           You came to us for reviews and it seems nobody has written one yet. We're going to take a cold shower to wash away the shame. In the meantime, maybe you could write the first review? The fame and fortune are yours for the taking.
         </p>

--- a/app/frontend/app/templates/reviews/index.hbs
+++ b/app/frontend/app/templates/reviews/index.hbs
@@ -16,10 +16,10 @@
   {{else}}
     {{#unless canLoadMore}}
       <div class="trending-review-empty">
-        <i class="empty-icon fa fa-meh"></i>
+        <i class="empty-icon fa fa-meh-o"></i>
         <h4> Well, this is pretty awkward.</h4>
         <p>
-          You came to us for reviews and it seems nobody has written one yet. We're going to take a cold shower to wash away the shame. In the meantime, maybe you could write the first review? The fortune and fame are yours for the taking.
+          You came to us for reviews and it seems nobody has written one yet. We're going to take a cold shower to wash away the shame. In the meantime, maybe you could write the first review? The fame and fortune are yours for the taking.
         </p>
         <a {{bind-attr href=anime.newReviewURL}} class="btn.btn-default">
           Write the first review


### PR DESCRIPTION
*GitHub thinks the repo is empty on the server so instead of wasting even more hours to let me reopen it I created a new PR :(*

AND:

- Shorter message for when there are no reviews,

- Remove `meh` icon on anime index's review,

- Hide review links when there are no reviews,
  - Write One => Duplicate link of button added when there are no reviews,
  - View All => Only takes you to an empty page when there are no reviews.