### PR TITLE
fix library status reset bug

### DIFF
--- a/app/frontend/app/routes/anime/index.js
+++ b/app/frontend/app/routes/anime/index.js
@@ -25,7 +25,12 @@ export default Ember.Route.extend({
       return libraryEntry.save();
     }), {
       progressMessage: "Saving " + anime.get('canonicalTitle') + "...",
-      successMessage: "Saved " + anime.get('canonicalTitle') + "!"
+      successMessage: function() {
+        // update the 'full-anime' relationship, since it seems to
+        // disappear into the void
+        anime.set('libraryEntry', libraryEntry);
+        return "Saved " + anime.get('canonicalTitle') + "!";
+      }
     });
   },
 
@@ -52,7 +57,7 @@ export default Ember.Route.extend({
       }
       return this.saveLibraryEntry(libraryEntry);
     },
-    
+
     toggleFavorite: function() {
       if (!this.get('currentUser.isSignedIn')){
         alert('Need to be signed in');

--- a/app/frontend/app/routes/manga.js
+++ b/app/frontend/app/routes/manga.js
@@ -12,7 +12,12 @@ export default Ember.Route.extend({
       return mangaLibraryEntry.save();
     }), {
       progressMessage: "Saving " + manga.get('romajiTitle') + "...",
-      successMessage: "Saved " + manga.get('romajiTitle') + "!"
+      successMessage: function() {
+        // update the 'full-manga' relationship since it seems
+        // to disappear into the void
+        manga.set('mangaLibraryEntry', mangaLibraryEntry);
+        return "Saved " + manga.get('romajiTitle') + "!";
+      }
     });
   },
 


### PR DESCRIPTION
ref: https://forums.hummingbird.me/t/changing-library-info-on-anime-pages-results-in-resets-and-errors/20471

Weird bug, where once we serialize the `LibraryEntry` with its `Anime` object from the server, the relationship between `FullAnime <-> LibraryEntry` gets set to null. ¯\\\_(ツ)_/¯