### PR TITLE
Default adult content to false

### DIFF
--- a/app/services/action.rb
+++ b/app/services/action.rb
@@ -24,7 +24,7 @@ class Action
         story_type: "comment",
         user: data[:user],
         target: data[:poster],
-        adult: data[:adult]
+        adult: data[:adult] || false
       )
 
       substory = Substory.create(


### PR DESCRIPTION
Tenpenchii doesn't provide this field so the value ends up being set as `null` which effectively marks it as adult content.