### PR TITLE
Worker fixes

### DIFF
--- a/app/workers/my_anime_list_import_apply_worker.rb
+++ b/app/workers/my_anime_list_import_apply_worker.rb
@@ -1,5 +1,7 @@
 class MyAnimeListImportApplyWorker
   include Sidekiq::Worker
+  # TODO: actually fix the bug
+  sidekiq_options retry: false
 
   def perform(user_id, xml)
     user = User.find(user_id)

--- a/app/workers/pro_expiry_email_worker.rb
+++ b/app/workers/pro_expiry_email_worker.rb
@@ -4,10 +4,10 @@ class ProExpiryEmailWorker
 
   recurrence { daily }
 
-  def perform
+  def perform(last, current)
     # Any users with nonrecurring plans expiring in the next 24 hours
     users = User.where(pro_membership_plan_id: ProMembershipPlan.nonrecurring_plans.map(&:id),
-                       pro_expires_at: (Time.now)..(1.day.from_now))
+                       pro_expires_at: (current)..(current + 1.day))
 
     users.all.each do |user|
       ProMailer.expiring_email(user)

--- a/app/workers/pro_renew_retry_worker.rb
+++ b/app/workers/pro_renew_retry_worker.rb
@@ -4,15 +4,15 @@ class ProRenewRetryWorker
 
   recurrence { daily }
 
-  def perform
+  def perform(last, current)
     recurring_plans = ProMembershipPlan.recurring_plans.map(&:id)
     tries = Array.new(3)
     tries[0] = User.where(pro_membership_plan_id: recurring_plans,
-                          pro_expires_at: (2.days.ago)..(1.day.ago))
+                          pro_expires_at: (current - 2.days)..(current - 1.day))
     tries[1] = User.where(pro_membership_plan_id: recurring_plans,
-                          pro_expires_at: (4.days.ago)..(3.day.ago))
+                          pro_expires_at: (current - 4.days)..(current - 3.days))
     tries[2] = User.where(pro_membership_plan_id: recurring_plans,
-                          pro_expires_at: (6.days.ago)..(5.day.ago))
+                          pro_expires_at: (current - 6.days)..(current - 5.days))
 
     tries.each.with_index do |users, index|
       users.all.each do |user|

--- a/app/workers/pro_renew_worker.rb
+++ b/app/workers/pro_renew_worker.rb
@@ -5,9 +5,10 @@ class ProRenewWorker
   recurrence { hourly }
 
   def perform(last, current)
+    recurring_plans = ProMembershipPlan.recurring_plans.map(&:id)
     # Anything which wasn't caught in the last run, up until 1 hour from now
-    users = User.where(pro_membership_plan_id: ProMembershipPlan.recurring_plans.map(&:id),
-                       pro_expires_at: (last + 1.hour)..(1.hour.from_now.to_i))
+    users = User.where(pro_membership_plan_id: recurring_plans,
+                       pro_expires_at: (last + 1.hour)..(current + 1.hour))
 
     users.all.each do |user|
       manager = ProMembershipManager.new(user)


### PR DESCRIPTION
Moved everything in the billing workers to be relative to the `last` and `current` parameters, which should fix all the fucking typecast errors, and make them more robust.

Also includes a hotfix for the MAL import worker, which just disables retries for now (they're not helping and are actually breaking things!)