### PR TITLE
fix routing bug on favourites

### DIFF
--- a/app/frontend/app/templates/components/favorite-container.hbs
+++ b/app/frontend/app/templates/components/favorite-container.hbs
@@ -27,13 +27,13 @@
           {{else}}
             <li class="grid-thumb" {{bind-attr data-id=favorite.id}}>
               {{#if isAnimeContainer}}
-                {{#link-to 'anime' favorite.item}}
+                {{#link-to 'anime' favorite.item.id}}
                   <div class="thumbnail">
                     <img {{bind-attr src=favorite.item.posterImage}} />
                   </div>
                 {{/link-to}}
               {{else}}
-                {{#link-to 'manga' favorite.item}}
+                {{#link-to 'manga' favorite.item.id}}
                   <div class="thumbnail">
                     <img {{bind-attr src=favorite.item.posterImage}} />
                   </div>


### PR DESCRIPTION
When navigating to an anime page of a users favourited anime, it results in the page not loading with an error of: `Cannot read property 'NaN' of undefined`.

This is because it is attempting to use data that exists on a 'full-anime' object and not the current 'anime' object.