### PR TITLE
Not-really-minor-anymore fix for MAL import

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -101,7 +101,11 @@ class ApplicationController < ActionController::Base
   end
 
   # Render a JSON error with the given error message and status code.
-  def error!(message, status)
+  # Accepts parameters in either order for legacy reasons.
+  # Advised parameter order is status, message
+  def error!(status, message)
+    # Flip the params if status isn't a number
+    status, message = message, status unless status.is_a?(Fixnum)
     # If the message is a Hash of errors, we put it in standard ED form
     if message.is_a?(Hash)
       render json: {errors: message}, status: status

--- a/app/controllers/settings/import_controller.rb
+++ b/app/controllers/settings/import_controller.rb
@@ -34,9 +34,9 @@ class Settings::ImportController < ApplicationController
 
     mixpanel.track 'Imported from MyAnimeList', {email: current_user.email} if Rails.env.production?
   rescue Exception
-    error! 500, 'There was a problem importing your anime list.  Please send an
-                 email to josh@hummingbird.me with the file you are trying
-                 to import.'
+    error! 500, 'There was a problem importing your list.  Please send an email
+                 to josh@hummingbird.me with the file you are trying to import
+                 and we\'ll see what we can do.'
      raise
   end
 end

--- a/app/controllers/settings/import_controller.rb
+++ b/app/controllers/settings/import_controller.rb
@@ -33,7 +33,7 @@ class Settings::ImportController < ApplicationController
     mixpanel.track "Imported from MyAnimeList", {email: current_user.email} if Rails.env.production?
   rescue Exception
     error! 500, "There was a problem importing your anime list.  Please send an
-                 email to vikhyat@hummingbird.me with the file you are trying
+                 email to josh@hummingbird.me with the file you are trying
                  to import."
   end
 end

--- a/app/controllers/settings/import_controller.rb
+++ b/app/controllers/settings/import_controller.rb
@@ -8,23 +8,30 @@ class Settings::ImportController < ApplicationController
     hide_cover_image
 
     if params[:animelist]
+      file = params[:animelist]
       begin
-        if params[:animelist].content_type == "text/xml"
-          xml = params[:animelist].read
-        else
-          gz = Zlib::GzipReader.new(params[:animelist])
+        # Check the magic number for gzip because some browsers are stupid
+        # Many users are uploading zipped-up lists with a text/xml MIME
+        if file.readpartial(3) == 0x1F_8B_08
+          gz = Zlib::GzipReader.new(file)
           xml = gz.read
           gz.close
+        elsif file.content_type.include?('xml')
+          xml = file.read
+        else
+          raise "Unknown format"
         end
 
         xml = XMLCleaner.clean(xml)
+
+        raise "Blank file" if xml.blank?
 
         current_user.update_column :mal_import_in_progress, true
         MyAnimeListImportApplyWorker.perform_async(current_user.id, xml)
 
         mixpanel.track "Imported from MyAnimeList", {email: current_user.email} if Rails.env.production?
-      rescue
-        flash[:error] = "There was a problem importing your anime list. Please send an email to <a href='mailto:vikhyat@hummingbird.me'>vikhyat@hummingbird.me</a> with the file you are trying to import.".html_safe
+      rescue Exception => e
+        flash[:error] = "There was a problem importing your anime list (#{e.message}).  Please send an email to <a href='mailto:vikhyat@hummingbird.me'>vikhyat@hummingbird.me</a> with the file you are trying to import.".html_safe
         redirect_to "/users/edit"
         return
       end

--- a/app/controllers/settings/import_controller.rb
+++ b/app/controllers/settings/import_controller.rb
@@ -17,11 +17,11 @@ class Settings::ImportController < ApplicationController
     elsif file.content_type.include?('xml')
       xml = file.read
     else
-      return error!(400, "Unknown format")
+      return error!(400, 'Unknown format')
     end
     xml = XMLCleaner.clean(xml)
 
-    return error!(422, "Blank file") if xml.blank?
+    return error!(422, 'Blank file') if xml.blank?
 
     # Queue the import
     current_user.update_columns import_status: :queued,
@@ -30,10 +30,10 @@ class Settings::ImportController < ApplicationController
 
     render json: current_user
 
-    mixpanel.track "Imported from MyAnimeList", {email: current_user.email} if Rails.env.production?
+    mixpanel.track 'Imported from MyAnimeList', {email: current_user.email} if Rails.env.production?
   rescue Exception
-    error! 500, "There was a problem importing your anime list.  Please send an
+    error! 500, 'There was a problem importing your anime list.  Please send an
                  email to josh@hummingbird.me with the file you are trying
-                 to import."
+                 to import.'
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,7 +45,6 @@
 #  authentication_token        :string(255)
 #  avatar_processing           :boolean
 #  subscribed_to_newsletter    :boolean          default(TRUE)
-#  mal_import_in_progress      :boolean
 #  waifu                       :string(255)
 #  location                    :string(255)
 #  website                     :string(255)
@@ -63,6 +62,9 @@
 #  pro_membership_plan_id      :integer
 #  stripe_customer_id          :string(255)
 #  about_formatted             :text
+#  import_status               :integer
+#  import_from                 :string(255)
+#  import_error                :string(255)
 #
 
 class User < ActiveRecord::Base
@@ -213,6 +215,8 @@ class User < ActiveRecord::Base
 
   validates :title_language_preference, inclusion: {in: %w[canonical english romanized]}
 
+  enum import_status: {queued: 1, running: 2, complete: 3, error: 4}
+
   def to_s
     name
   end
@@ -316,7 +320,7 @@ class User < ActiveRecord::Base
     user.confirm!
     return user
   end
-  
+
   # Set this user's facebook_id to the passed in `uid`.
   #
   # Returns nothing.

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -8,7 +8,10 @@ class CurrentUserSerializer < UserSerializer
              :has_dropbox?,
              :has_facebook?,
              :confirmed?,
-             :pro_expires_at
+             :pro_expires_at,
+             :import_status,
+             :import_from,
+             :import_error
 
   has_one :pro_membership_plan
 

--- a/app/workers/my_anime_list_import_apply_worker.rb
+++ b/app/workers/my_anime_list_import_apply_worker.rb
@@ -8,6 +8,9 @@ class MyAnimeListImportApplyWorker
     malimport = MyAnimeListImport.new(user, xml)
     malimport.apply!
     user.recompute_life_spent_on_anime!
-    user.update_column :mal_import_in_progress, false
+    user.update_columns import_status: nil, import_from: nil, import_error: nil
+  rescue Exception
+    user.update_columns import_status: :error, import_error: "There was a problem importing your anime list.  Please send an email to vikhyat@hummingbird.me with the file you are trying to import."
+    raise
   end
 end

--- a/app/workers/my_anime_list_import_apply_worker.rb
+++ b/app/workers/my_anime_list_import_apply_worker.rb
@@ -10,7 +10,8 @@ class MyAnimeListImportApplyWorker
     user.recompute_life_spent_on_anime!
     user.update_columns import_status: nil, import_from: nil, import_error: nil
   rescue Exception
-    user.update_columns import_status: :error,
+    status = User.import_statuses[:error]
+    user.update_columns import_status: status,
       import_error: 'There was a problem importing your anime list.  Please
                      send an email to josh@hummingbird.me with the file you
                      are trying to import.'

--- a/app/workers/my_anime_list_import_apply_worker.rb
+++ b/app/workers/my_anime_list_import_apply_worker.rb
@@ -12,9 +12,9 @@ class MyAnimeListImportApplyWorker
   rescue Exception
     status = User.import_statuses[:error]
     user.update_columns import_status: status,
-      import_error: 'There was a problem importing your anime list.  Please
-                     send an email to josh@hummingbird.me with the file you
-                     are trying to import.'
+      import_error: 'There was a problem importing your list.  Please send an
+                     email to josh@hummingbird.me with the file you are trying
+                     to import and we\'ll see what we can do.'
     raise
   end
 end

--- a/app/workers/my_anime_list_import_apply_worker.rb
+++ b/app/workers/my_anime_list_import_apply_worker.rb
@@ -10,7 +10,8 @@ class MyAnimeListImportApplyWorker
     user.recompute_life_spent_on_anime!
     user.update_columns import_status: nil, import_from: nil, import_error: nil
   rescue Exception
-    user.update_columns import_status: :error, import_error: "There was a problem importing your anime list.  Please send an email to vikhyat@hummingbird.me with the file you are trying to import."
+    user.update_columns import_status: :error,
+      import_error: "There was a problem importing your anime list.  Please send an email to josh@hummingbird.me with the file you are trying to import."
     raise
   end
 end

--- a/app/workers/my_anime_list_import_apply_worker.rb
+++ b/app/workers/my_anime_list_import_apply_worker.rb
@@ -11,7 +11,9 @@ class MyAnimeListImportApplyWorker
     user.update_columns import_status: nil, import_from: nil, import_error: nil
   rescue Exception
     user.update_columns import_status: :error,
-      import_error: "There was a problem importing your anime list.  Please send an email to josh@hummingbird.me with the file you are trying to import."
+      import_error: 'There was a problem importing your anime list.  Please
+                     send an email to josh@hummingbird.me with the file you
+                     are trying to import.'
     raise
   end
 end

--- a/db/migrate/20150204092920_split_mal_import_column_on_users.rb
+++ b/db/migrate/20150204092920_split_mal_import_column_on_users.rb
@@ -1,0 +1,15 @@
+class SplitMalImportColumnOnUsers < ActiveRecord::Migration
+  def up
+    change_table :users do |t|
+      t.integer :import_status
+      t.string :import_from
+      t.string :import_error
+
+      # status is enum queued: 1, running: 2, complete: 3, error: 4
+      User.where(mal_import_in_progress: true)
+          .update_all(import_status: 2, import_from: 'myanimelist')
+
+      t.remove :mal_import_in_progress
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1645,7 +1645,6 @@ CREATE TABLE users (
     authentication_token character varying(255),
     avatar_processing boolean,
     subscribed_to_newsletter boolean DEFAULT true,
-    mal_import_in_progress boolean,
     waifu character varying(255),
     location character varying(255),
     website character varying(255),
@@ -1662,7 +1661,10 @@ CREATE TABLE users (
     stripe_token character varying(255),
     pro_membership_plan_id integer,
     stripe_customer_id character varying(255),
-    about_formatted text
+    about_formatted text,
+    import_status integer,
+    import_from character varying(255),
+    import_error character varying(255)
 );
 
 
@@ -3829,4 +3831,6 @@ INSERT INTO schema_migrations (version) VALUES ('20150426012023');
 INSERT INTO schema_migrations (version) VALUES ('20150504184112');
 
 INSERT INTO schema_migrations (version) VALUES ('20150427224114');
+
+INSERT INTO schema_migrations (version) VALUES ('20150204092920');
 

--- a/frontend/app/controllers/onboarding/library.js
+++ b/frontend/app/controllers/onboarding/library.js
@@ -90,9 +90,9 @@ export default Ember.Controller.extend({
     },
 
     importMal: function(file) {
-      let user = this.get('currentUser');
-      user.importList('myanmelist', file).then(function() {
-        Ember.run.later(function(){
+      let user = this.get('currentUser.content.content');
+      user.importList('myanimelist', file).then(() => {
+        Ember.run.later(() => {
           this.transitionToRoute('onboarding.finish');
         }, 1000);
       });

--- a/frontend/app/controllers/onboarding/library.js
+++ b/frontend/app/controllers/onboarding/library.js
@@ -85,15 +85,15 @@ export default Ember.Controller.extend({
       });
     },
 
-    importLibrary: function(){
-      var self = this;
-      ajax({
-        url: '/settings/import/myanimelist',
-        type: 'POST'
-      }).then(function() {
-        self.set('importFromMal', true);
+    pickMalFile: function() {
+      Ember.$('#mal-file').click();
+    },
+
+    importMal: function(file) {
+      let user = this.get('currentUser');
+      user.importList('myanmelist', file).then(function() {
         Ember.run.later(function(){
-          self.transitionToRoute('onboarding.finish');
+          this.transitionToRoute('onboarding.finish');
         }, 1000);
       });
     },

--- a/frontend/app/controllers/settings.js
+++ b/frontend/app/controllers/settings.js
@@ -126,10 +126,10 @@ export default Ember.Controller.extend({
       Ember.$('#hb-file').click();
     },
     importHummingbird: function(file) {
-      this.get('currentUser').importList('hummingbird', file);
+      this.get('currentUser.content.content').importList('hummingbird', file);
     },
     importMal: function(file) {
-      this.get('currentUser').importList('myanimelist', file);
+      this.get('currentUser.content.content').importList('myanimelist', file);
     }
   }
 });

--- a/frontend/app/controllers/settings.js
+++ b/frontend/app/controllers/settings.js
@@ -84,6 +84,34 @@ export default Ember.Controller.extend({
            !this.get('usernameValid');
   }.property('currentUser.isDirty', 'passwordValid', 'usernameValid'),
 
+  importList: function(service, file) {
+    var data = new FormData();
+    data.append('list', file);
+    return ajax('/settings/import/' + service, {
+      data: data,
+      cache: false,
+      contentType: false,
+      processData: false,
+      type: 'POST'
+    }).then(() => {
+      this.store.update('currentUser', {
+        id: this.get('currentUser.id'),
+        importStatus: 'queued',
+        importingFrom: service
+      });
+    }, (err) => {
+      try {
+        this.store.update('currentUser', {
+          id: this.get('currentUser.id'),
+          importStatus: 'error',
+          importError: err.jqXHR.responseJSON.error
+        });
+      } catch (e) {
+        alert('An unknown error occurred while attempting to import your list');
+      }
+    });
+  },
+
   actions: {
     save: function() {
       var self = this;
@@ -125,11 +153,11 @@ export default Ember.Controller.extend({
     pickHbFile: function() {
       Ember.$('#hb-file').click();
     },
-    restoreBackup: function() {
-      Ember.$('#backuprestore').submit();
+    importHummingbird: function(file) {
+      this.importList('hummingbird', file);
     },
-    importMal: function() {
-      Ember.$('#malimport').submit();
+    importMal: function(file) {
+      this.importList('myanimelist', file);
     }
   }
 });

--- a/frontend/app/controllers/settings.js
+++ b/frontend/app/controllers/settings.js
@@ -84,34 +84,6 @@ export default Ember.Controller.extend({
            !this.get('usernameValid');
   }.property('currentUser.isDirty', 'passwordValid', 'usernameValid'),
 
-  importList: function(service, file) {
-    var data = new FormData();
-    data.append('list', file);
-    return ajax('/settings/import/' + service, {
-      data: data,
-      cache: false,
-      contentType: false,
-      processData: false,
-      type: 'POST'
-    }).then(() => {
-      this.store.update('currentUser', {
-        id: this.get('currentUser.id'),
-        importStatus: 'queued',
-        importingFrom: service
-      });
-    }, (err) => {
-      try {
-        this.store.update('currentUser', {
-          id: this.get('currentUser.id'),
-          importStatus: 'error',
-          importError: err.jqXHR.responseJSON.error
-        });
-      } catch (e) {
-        alert('An unknown error occurred while attempting to import your list');
-      }
-    });
-  },
-
   actions: {
     save: function() {
       var self = this;
@@ -154,10 +126,10 @@ export default Ember.Controller.extend({
       Ember.$('#hb-file').click();
     },
     importHummingbird: function(file) {
-      this.importList('hummingbird', file);
+      this.get('currentUser').importList('hummingbird', file);
     },
     importMal: function(file) {
-      this.importList('myanimelist', file);
+      this.get('currentUser').importList('myanimelist', file);
     }
   }
 });

--- a/frontend/app/models/current-user.js
+++ b/frontend/app/models/current-user.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 import User from '../models/user';
+import ajax from 'ic-ajax';
 
 export default User.extend({
   newUsername: DS.attr('string'),

--- a/frontend/app/models/current-user.js
+++ b/frontend/app/models/current-user.js
@@ -52,7 +52,7 @@ export default User.extend({
           importError: err.jqXHR.responseJSON.error
         });
       } catch (e) {
-        alert("An unknown error occurred while attempting to import your list. Send an email to josh@hummingbird.me and we'll try to make it right");
+        alert("There was a problem importing your list. Send an email to josh@hummingbird.me with the file you're trying to import and we'll see what we can do.");
       }
     });
   }

--- a/frontend/app/models/current-user.js
+++ b/frontend/app/models/current-user.js
@@ -39,14 +39,14 @@ export default User.extend({
       processData: false,
       type: 'POST'
     }).then(() => {
-      this.store.update('currentUser', {
+      this.store.push('currentUser', {
         id: this.get('id'),
         importStatus: 'queued',
-        importingFrom: service
+        importFrom: service
       });
     }, (err) => {
       try {
-        this.store.update('currentUser', {
+        this.store.push('currentUser', {
           id: this.get('id'),
           importStatus: 'error',
           importError: err.jqXHR.responseJSON.error

--- a/frontend/app/models/current-user.js
+++ b/frontend/app/models/current-user.js
@@ -31,7 +31,7 @@ export default User.extend({
   // saved as a data:uri
   importList: function(service, file) {
     let data = new FormData();
-    data.append('list', file);
+    data.append('file', file);
     return ajax('/settings/import/' + service, {
       data: data,
       cache: false,
@@ -52,9 +52,7 @@ export default User.extend({
           importError: err.jqXHR.responseJSON.error
         });
       } catch (e) {
-        alert(`An unknown error occurred while attempting to import your list.
-               Send an email to josh@hummingbird.me and we'll try to make it
-               right`);
+        alert("An unknown error occurred while attempting to import your list. Send an email to josh@hummingbird.me and we'll try to make it right");
       }
     });
   }

--- a/frontend/app/models/current-user.js
+++ b/frontend/app/models/current-user.js
@@ -9,10 +9,19 @@ export default User.extend({
   sfwFilter: DS.attr('boolean'),
   lastBackup: DS.attr('date'),
   hasDropbox: DS.attr('boolean'),
+  importStatus: DS.attr('string'),
+  importFrom: DS.attr('string'),
+  importError: DS.attr('string'),
   hasFacebook: DS.attr('boolean'),
   confirmed: DS.attr('boolean'),
   proExpiresAt: DS.attr('date'),
   proMembershipPlan: DS.belongsTo('pro-membership-plan'),
+
+  isImportOngoing: function() {
+    var status = this.get('importStatus');
+    return status === 'queued' || status === 'running';
+  }.property('importStatus'),
+  isImportErrored: Ember.computed.equal('importStatus', 'error'),
 
   // Temporary solution for beta indicator
   betaAccess: Ember.computed.or('isAdmin', 'isPro')

--- a/frontend/app/templates/onboarding/library.hbs
+++ b/frontend/app/templates/onboarding/library.hbs
@@ -12,11 +12,17 @@
   {{/if}}
   <div class="col-sm-12">
     <div class="import-panel">
-      {{#if importFromMal}}
-        <i class="fa fa-spinner"></i> Hang tight, we're importing your data.
+      {{#if currentUser.isImportErrored}}
+        <i class="fa fa-warning"></i> {{currentUser.importError}}
       {{else}}
-        Have a MAL account? <a href="#" {{action 'importLibrary'}}>We can import your XML back-up!</a>
-        <a href="http://myanimelist.net/panel.php?go=export" target="_blank" class="import-help"><i class="fa fa-question-circle"></i></a>
+        {{#if currentUser.isImportOngoing}}
+          <i class="fa fa-spinner"></i>
+          We're importing your data.  Keep going, we'll tell you when it's done.
+        {{else}}
+          {{view "file-upload" action="importMal" name="animelist" id="mal-file"}}
+          Have a MAL account? <a href="#" {{action "pickMalFile"}}>We can import your XML backup!</a>
+          <a href="http://myanimelist.net/panel.php?go=export" target="_blank" class="import-help"><i class="fa fa-question-circle"></i></a>
+        {{/if}}
       {{/if}}
     </div>
   </div>

--- a/frontend/app/templates/onboarding/library.hbs
+++ b/frontend/app/templates/onboarding/library.hbs
@@ -14,15 +14,14 @@
     <div class="import-panel">
       {{#if currentUser.isImportErrored}}
         <i class="fa fa-warning"></i> {{currentUser.importError}}
+      {{/if}}
+      {{#if currentUser.isImportOngoing}}
+        <i class="fa fa-spinner"></i>
+        We're importing your data.  Keep going, we'll tell you when it's done.
       {{else}}
-        {{#if currentUser.isImportOngoing}}
-          <i class="fa fa-spinner"></i>
-          We're importing your data.  Keep going, we'll tell you when it's done.
-        {{else}}
-          {{view "file-upload" action="importMal" name="animelist" id="mal-file"}}
-          Have a MAL account? <a href="#" {{action "pickMalFile"}}>We can import your XML backup!</a>
-          <a href="http://myanimelist.net/panel.php?go=export" target="_blank" class="import-help"><i class="fa fa-question-circle"></i></a>
-        {{/if}}
+        {{view "file-upload" action="importMal" name="animelist" id="mal-file"}}
+        Have a MAL account? <a href="#" {{action "pickMalFile"}}>We can import your XML backup!</a>
+        <a href="http://myanimelist.net/panel.php?go=export" target="_blank" class="import-help"><i class="fa fa-question-circle"></i></a>
       {{/if}}
     </div>
   </div>

--- a/frontend/app/templates/onboarding/library.hbs
+++ b/frontend/app/templates/onboarding/library.hbs
@@ -17,7 +17,7 @@
       {{/if}}
       {{#if currentUser.isImportOngoing}}
         <i class="fa fa-spinner"></i>
-        We're importing your data.  Keep going, we'll tell you when it's done.
+        We're importing your data. Keep going, we'll tell you when it's done.
       {{else}}
         {{view "file-upload" action="importMal" name="animelist" id="mal-file"}}
         Have a MAL account? <a href="#" {{action "pickMalFile"}}>We can import your XML backup!</a>

--- a/frontend/app/templates/settings.hbs
+++ b/frontend/app/templates/settings.hbs
@@ -61,6 +61,11 @@
           <span class="last-backup">last backup: {{time-ago time=currentUser.lastBackup}}</span>
         </div>
         <div class="panel-body">
+          {{#if currentUser.isImportErrored}}
+            <div class="alert alert-danger">
+              <p><i class="fa fa-warning"></i> {{currentUser.importError}}</p>
+            </div>
+          {{/if}}
           <div class="row">
             <label class="control-label col-sm-6">Dropbox Backup</label>
             <div class="col-sm-6">
@@ -87,16 +92,18 @@
             </div>
           </div>
           <div class="row">
-            <label class="control-label col-sm-6">MAL Import</label>
-            <div class="col-sm-6">
-              <form action="/settings/import/myanimelist" method="post" id="malimport" enctype="multipart/form-data">
+            {{#if user.isImportOngoing}}
+              <i class="fa fa-2x fa-spinner fa-spin"></i>
+              Importing...
+            {{else}}
+              <label class="control-label col-sm-6">MAL Import</label>
+              <div class="col-sm-6">
                 {{view "file-upload" action="importMal" name="animelist" id="mal-file"}}
-                <input type="hidden" name="authenticity_token" {{bind-attr value=csrfToken}}>
-              </form>
-              <button type="button" class="col-sm-6 col-sm-offset-6 btn btn-default" {{action "pickMalFile"}}>
-                Upload
-              </button>
-            </div>
+                <button class="col-sm-6 col-sm-offset-6 btn btn-default" {{action "pickMalFile"}}>
+                  Upload
+                </button>
+              </div>
+            {{/if}}
           </div>
         </div>
       </div>

--- a/frontend/app/templates/settings.hbs
+++ b/frontend/app/templates/settings.hbs
@@ -92,9 +92,11 @@
             </div>
           </div>
           <div class="row">
-            {{#if user.isImportOngoing}}
-              <i class="fa fa-2x fa-spinner fa-spin"></i>
-              Importing...
+            {{#if currentUser.isImportOngoing}}
+              <label class="control-label col-sm-6">
+                <i class="fa fa-spinner fa-spin"></i>
+                Importing...
+              </label>
             {{else}}
               <label class="control-label col-sm-6">MAL Import</label>
               <div class="col-sm-6">

--- a/frontend/app/views/file-upload.js
+++ b/frontend/app/views/file-upload.js
@@ -4,11 +4,18 @@ export default Ember.TextField.extend({
   type: 'file',
   attributeBindings: ['name'],
   classNames: ['hidden'],
+  file: null,
 
   change: function(evt) {
     var input = evt.target;
     if (input.files && input.files[0]) {
-      return this.sendAction('action', input.files[0]);
+      // Update bindings
+      var reader = new FileReader();
+      reader.onload = (e) => Ember.run(() => this.set('file', e.target.result));
+      reader.readAsDataURL(input.files[0]);
+
+      // Send action
+      this.sendAction('action', input.files[0]);
     }
   }
 });

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -45,7 +45,6 @@
 #  authentication_token        :string(255)
 #  avatar_processing           :boolean
 #  subscribed_to_newsletter    :boolean          default(TRUE)
-#  mal_import_in_progress      :boolean
 #  waifu                       :string(255)
 #  location                    :string(255)
 #  website                     :string(255)
@@ -63,6 +62,9 @@
 #  pro_membership_plan_id      :integer
 #  stripe_customer_id          :string(255)
 #  about_formatted             :text
+#  import_status               :integer
+#  import_from                 :string(255)
+#  import_error                :string(255)
 #
 
 vikhyat:
@@ -108,7 +110,6 @@ vikhyat:
   authentication_token: CWZeN12y1seSwMEqtWbd
   avatar_processing: false
   subscribed_to_newsletter: true
-  mal_import_in_progress: false
   approved_edit_count: 0
   rejected_edit_count: 0
 
@@ -154,7 +155,6 @@ josh:
   authentication_token: gpY9LhJopfsNwJmiXx1h
   avatar_processing: false
   subscribed_to_newsletter: true
-  mal_import_in_progress:
   approved_edit_count: 0
   rejected_edit_count: 0
   pro_expires_at: 2020-01-01 19:37:18.851425000 Z

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -45,7 +45,6 @@
 #  authentication_token        :string(255)
 #  avatar_processing           :boolean
 #  subscribed_to_newsletter    :boolean          default(TRUE)
-#  mal_import_in_progress      :boolean
 #  waifu                       :string(255)
 #  location                    :string(255)
 #  website                     :string(255)
@@ -63,6 +62,9 @@
 #  pro_membership_plan_id      :integer
 #  stripe_customer_id          :string(255)
 #  about_formatted             :text
+#  import_status               :integer
+#  import_from                 :string(255)
+#  import_error                :string(255)
 #
 
 require 'test_helper'


### PR DESCRIPTION
DOES NOT fix the problem that was causing infinite retries; I have so far been unable to reproduce that issue locally.

But it *does* fix the constant empty-string imports.  Some (evidently quite common) combination of browser and operating system results in the `.xml.gz` file being uploaded as `.xml` — the best solution is to see if it's got the gzip magic number (`1F 8B 08`).  Another option is to use [Paperclip::ContentTypeDetector](http://www.rubydoc.info/github/thoughtbot/paperclip/Paperclip/ContentTypeDetector), which shells out to `file` and achieves the same thing.  It's a trade-off: we can either shell out or we can embed a magic number in our code.

It also switches to AJAX instead of the redirect-loop and provides a mechanism for getting errors out of the import system and back to the user.

Pivotal: https://www.pivotaltracker.com/story/show/91727174

### Todo:
 * [x] Update it in onboarding
 * [x] Toss a few files in the hole and test that it works right