### PR TITLE
Make QU background transition smoother

### DIFF
--- a/app/assets/stylesheets/components/quick-update.css.scss
+++ b/app/assets/stylesheets/components/quick-update.css.scss
@@ -66,8 +66,9 @@
     }
 
     .overlay-panel {
-      background-image: linear-gradient(rgba(0, 0, 0, .1), rgba(0, 0, 0, .80));
-      opacity: 1;
+      background-image: linear-gradient(rgba(0, 0, 0, .1), rgba(0, 0, 0, .80) 50%, rgba(0, 0, 0, .80) 100%);
+      background-size: 200%;
+      background-repeat: repeat-x;
       border-radius: 3px;
       text-align: center;
       position: absolute;
@@ -76,7 +77,7 @@
       bottom: 0;
       left: 0;
       padding: 5px 10px;
-      transition: opacity .3s ease-in-out;
+      transition: background-position .3s ease-in-out;
     }
 
     .series-title {
@@ -110,7 +111,7 @@
 
     &:hover {
       .overlay-panel {
-        background-image: linear-gradient(rgba(0, 0, 0, .8), rgba(0, 0, 0, .8));
+        background-position: 0 100%;
       }
       .actionable, .series-title {
         opacity: 1;


### PR DESCRIPTION
Uses a gradient position change instead of an opacity change, so that the background appears to fade in along with the button and title

I just kind of got frustrated with how the background suddenly turns black but the other things fade in and whipped this out real fast in dev tools :D 

Obligatory gif:

![](https://s3.amazonaws.com/f.cl.ly/items/3Z1Z1S3I0T2x360m1J2e/Screen%20Recording%202015-01-27%20at%2007.07%20PM.gif)