### PR TITLE
Fix the whitespace above the Community box

### DIFF
--- a/app/assets/stylesheets/partials/dashboard-activity-feed.css.scss
+++ b/app/assets/stylesheets/partials/dashboard-activity-feed.css.scss
@@ -1,6 +1,6 @@
 .feed-sidebar-advert,
 .community-widget-panel {
-  float: none;
+  float: left;
 }
 
 .feed-sidebar-footer {


### PR DESCRIPTION
Margins collapsing caused it to go boom in some browsers.

Floating left seems to fix this.  Might break other things.

![](https://s3.amazonaws.com/f.cl.ly/items/3E2p0w2r3w3v3B2x0o3z/Image%202015-01-28%20at%2011.46.51%20PM.png)

#nuckfixestinynuisanceswhiletired

