### PR TITLE
Fixes a few auth bugs.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,10 @@ class ApplicationController < ActionController::Base
   include Auth::Helpers
 
   rescue_from 'Auth::UnauthorizedException' do
-    render json: {error: "Not authenticated"}, status: 403
+    respond_to do |format|
+      format.json { render json: {error: "Not authenticated"}, status: 403 }
+      format.html { redirect_to(sign_in_path) }
+    end
   end
 
   # Send an object along with the initial HTML response that will be loaded into

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -3,7 +3,7 @@ require_dependency 'auth/helpers'
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
-   config.secret_key = ENV['DEVISE_SECRET']
+  config.secret_key = ENV['DEVISE_SECRET']
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,
@@ -243,8 +243,11 @@ Devise.setup do |config|
 end
 
 Devise::Controllers::SignInOut.class_eval do
-
   include Auth::Helpers
+
+  def signed_in?(scope)
+    user_signed_in?
+  end
 
   def sign_in(resource_or_scope, *args)
     check_user_authentication

--- a/test/controllers/pro_memberships_controller_test.rb
+++ b/test/controllers/pro_memberships_controller_test.rb
@@ -3,7 +3,7 @@ require 'stripe_mock'
 
 class ProMembershipsControllerTest < ActionController::TestCase
   test "must be signed in" do
-    post :create
+    post :create, format: :json
     assert_response 403
   end
 


### PR DESCRIPTION
:beetle: :beetle: The Bugs! :beetle: :beetle: 
================================

1. With the new auth system, new users who sign up are getting redirected to `/users/sign_in` after confirming their email. This was due to `signed_in?` failing within devise.

![](http://cl.ly/image/0k3C2w2f0n2n/Image%202015-02-17%20at%204.04.04%20am.png)

2. When signing out on an `authenticate_user!` page, the user was redirected back to their referrer which would  render a JSON error to them.

![](http://cl.ly/image/2e0l1p143x0s/Image%202015-02-17%20at%204.06.14%20am.png)