### PR TITLE
Fix QU gradient for Firefox (browser-side malformed CSS)

### DIFF
--- a/app/assets/stylesheets/components/quick-update.css.scss
+++ b/app/assets/stylesheets/components/quick-update.css.scss
@@ -67,7 +67,7 @@
 
     .overlay-panel {
       background-image: linear-gradient(rgba(0, 0, 0, .1), rgba(0, 0, 0, .80) 50%, rgba(0, 0, 0, .80) 100%);
-      background-size: 200%;
+      background-size: auto 200%;
       background-repeat: repeat-x;
       border-radius: 3px;
       text-align: center;


### PR DESCRIPTION
https://forums.hummingbird.me/t/dark-overlay-on-quick-update/21893

Firefox seems to change the property to `background-size: 200% auto` which is 100% what we don't want. Applying `background-size: auto 200%` prevents this behaviour and works on all browsers.

FireFox 35:
![](http://a.pomf.se/nfbbax.png)

Chrome 42:
![](http://a.pomf.se/sydshc.png)