### PR TITLE
Group search & refactoring

### DIFF
--- a/app/api/api_v1.rb
+++ b/app/api/api_v1.rb
@@ -535,9 +535,9 @@ class API_v1 < Grape::API
   end
   get '/search/anime' do
     anime = Anime.accessible_by(current_ability).includes(:genres)
-    results = anime.simple_search_by_title(params[:query]).limit(20)
+    results = anime.instant_search(params[:query]).limit(20)
     if results.length == 0
-      results = anime.fuzzy_search_by_title(params[:query]).limit(20)
+      results = anime.full_search(params[:query]).limit(20)
     end
 
     title_language_preference = params[:title_language_preference]

--- a/app/frontend/app/components/favorite-search.js
+++ b/app/frontend/app/components/favorite-search.js
@@ -13,20 +13,9 @@ export default Ember.Component.extend({
       queryTokenizer: Bloodhound.tokenizers.whitespace,
       limit: 10,
       remote: {
-        url: '/search.json?query=%QUERY&type=mixed',
+        url: '/search.json?scope=all&depth=instant&query=%QUERY',
         filter: function(results) {
-          return Ember.$.map(results.search, function (r) {
-            // There actually has to be a way to send the img params to the thumb generator in the request, this is just a temp. solution
-            if (r.type === "user") {
-              r.image = r.image.replace(/(\.[a-zA-Z]+)?\?/, ".jpg?");
-            }
-            return {
-              title: r.title,
-              type: r.type,
-              image: r.image.replace((r.type==="user"?"{size}":"large"), (r.type==="user"?"small":"medium")),
-              slug: r.slug
-            };
-          });
+          return results.search;
         }
       }
     });

--- a/app/frontend/app/components/instant-search.js
+++ b/app/frontend/app/components/instant-search.js
@@ -13,20 +13,9 @@ export default Ember.Component.extend({
       queryTokenizer: Bloodhound.tokenizers.whitespace,
       limit: 8,
       remote: {
-        url: '/search.json?query=%QUERY&type=mixed',
+        url: '/search.json?scope=all&depth=instant&query=%QUERY',
         filter: function(results) {
-          return Ember.$.map(results.search, function (r) {
-            // There actually has to be a way to send the img params to the thumb generator in the request, this is just a temp. solution
-            if (r.type === "user") {
-              r.image = r.image.replace(/(\.[a-zA-Z]+)?\?/, ".jpg?");
-            }
-            return {
-              title: r.title,
-              type: r.type,
-              image: r.image.replace((r.type==="user"?"{size}":"large"), (r.type==="user"?"small":"medium")),
-              link: r.link
-            };
-          });
+          return results.search;
         }
       }
     });
@@ -38,10 +27,9 @@ export default Ember.Component.extend({
   collapsed: true,
 
   updateSearchResults: function() {
-    var self = this;
     if (this.get('query').length > 2) {
-      this.get('bloodhound').get(this.get('query'), function(results) {
-        self.set('searchResults', results);
+      this.get('bloodhound').get(this.get('query'), (results) => {
+        this.set('searchResults', results);
       });
     }
   },

--- a/app/frontend/app/components/instant-search.js
+++ b/app/frontend/app/components/instant-search.js
@@ -61,7 +61,7 @@ export default Ember.Component.extend({
     },
 
     submitQuery: function() {
-      window.location.href = "/search?query=" + this.get('query');
+      this.sendAction('action', this.get('query'));
     }
   }
 });

--- a/app/frontend/app/components/waifu-selector.js
+++ b/app/frontend/app/components/waifu-selector.js
@@ -24,12 +24,12 @@ export default Ember.Component.extend({
       },
       queryTokenizer: Bloodhound.tokenizers.whitespace,
       remote: {
-        url: '/search.json?query=%QUERY&type=character',
+        url: '/search.json?scope=character&depth=instant&query=%QUERY',
         filter: function(characters) {
           return Ember.$.map(characters.search, function(character) {
             return {
               value: character.name,
-              char_id: character.id
+              char_id: character.link
             };
           });
         }

--- a/app/frontend/app/controllers/header.js
+++ b/app/frontend/app/controllers/header.js
@@ -32,8 +32,10 @@ export default Ember.Controller.extend(HasCurrentUser, {
   unconfirmed: Ember.computed.equal('currentUser.confirmed', false),
 
   actions: {
-    submitSearch: function () {
-      return window.location.replace("/search?query=" + this.get('searchTerm'));
+    submitSearch: function (query) {
+      return this.transitionToRoute('search', {
+        queryParams: {query}
+      });
     },
     toggleUpdater: function () {
       this.toggleProperty('showUpdater');

--- a/app/frontend/app/controllers/onboarding/library.js
+++ b/app/frontend/app/controllers/onboarding/library.js
@@ -55,7 +55,7 @@ export default Ember.Controller.extend(HasCurrentUser, {
 
     this.set('loading', true);
     ajax({
-      url: '/search.json?type=element&datatype='+dtpe+'&query=' + this.get('searchTerm'),
+      url: '/search.json?depth=element&scope='+dtpe+'&query=' + this.get('searchTerm'),
       type: "GET"
     }).then(function(payload) {
       self.setProperties({

--- a/app/frontend/app/controllers/search.js
+++ b/app/frontend/app/controllers/search.js
@@ -2,57 +2,60 @@ import Ember from 'ember';
 import ajax from 'ic-ajax';
 
 export default Ember.Controller.extend({
-  filters: ["Everything", "Anime", "Manga", "User"],
-  queryParams: ['query', 'filter'],
+  scopes: [
+    { value: 'all', label: 'Everything' },
+    { value: 'anime', label: 'Anime' },
+    { value: 'manga', label: 'Manga' },
+    { value: 'users', label: 'Users' },
+    { value: 'groups', label: 'Groups' },
+  ],
+  queryParams: {
+    query: { replace: true },
+    scope: { }
+  },
   performingSearch: false,
   performedSearch: false,
-  userTypedSearch: false,
   searchResults: [],
-  searchRequest: "",
-  filter: "Everything",
-  query: "",
-
-  filteredSearchResults: function(){
-    var self = this;
-    return this.get('searchResults').filter(function(result){
-      return (result.type === self.get('filter').toLowerCase() || "Everything" === self.get('filter'));
-    });
-  }.property('searchResults', 'filter'),
+  searchRequest: '',
+  scope: 'all',
+  query: '',
 
   observeQuery: function() {
-    if (this.get('query.length') >= 2) {
-      Ember.run.debounce(this, this.performSearch, 500);
+    if (this.get('query').length > 2) {
+      Ember.run.debounce(this, this.performSearch, 400);
     }
   }.observes('query'),
 
+  observeScope: function() {
+    if (this.get('query').length > 2) {
+      this.performSearch();
+    }
+  }.observes('scope'),
+
   performSearch: function() {
     if (this.get('performingSearch')) {
-      Ember.run.later(this, this.performSearch, 100);
-      return;
+      return Ember.run.later(this, this.performSearch, 100);
     }
 
-    var self = this;
-
-    if(this.get('query').length < 2){
-      this.setProperties({
-        'searchResults': [],
-        'searchRequest': self.get('query')+' (too short, min. 2 chars)',
-        'performedSearch': true
+    if (this.get('query').length < 3) {
+      return this.setProperties({
+        searchResults: [],
+        searchRequest: this.get('query')+' (too short, min. 3 chars)',
+        performedSearch: true,
+        performingSearch: false
       });
-      return;
     }
 
     this.set('performingSearch', true);
     ajax({
-      url: '/search.json?type=full&query=' + this.get('query'),
-      type: "GET"
-    }).then(function(payload) {
-      self.set('performingSearch', false);
-      var query = self.get('query');
-      self.setProperties({
-        'searchResults': payload.search,
-        'searchRequest': query,
-        'performedSearch': true
+      url: '/search.json?depth=full&scope=' + this.get('scope') + '&query=' + this.get('query'),
+      type: 'GET'
+    }).then((payload) => {
+      this.setProperties({
+        searchResults: payload.search,
+        searchRequest: this.get('query'),
+        performedSearch: true,
+        performingSearch: false
       });
     });
   },

--- a/app/frontend/app/templates/components/instant-search.hbs
+++ b/app/frontend/app/templates/components/instant-search.hbs
@@ -7,14 +7,14 @@
     <ul class="search-dropdown">
       {{#each result in searchResults}}
         <li class="search-result">
-          <a {{bind-attr href="result.link" title="result.title"}}>
+          {{#link-to result.type result.link title="result.title"}}
             <div class="search-result-thumb">
               <img {{bind-attr src="result.image"}} />
             </div>
             <div class="search-result-title">{{result.title}}</div>
             <span {{bind-attr class=":search-result-badge :badge result.type"}}>{{result.type}}</span>
             <div class="search-result-break"></div>
-          </a>
+          {{/link-to}}
         </li>
       {{/each}}
       <li class="search-result show-more">

--- a/app/frontend/app/templates/search.hbs
+++ b/app/frontend/app/templates/search.hbs
@@ -8,7 +8,11 @@
         {{input value=query class="form-control" placeholder="I'm sure there's something interesting to find here!"}}
       </div>
       <div class="col-md-3">
-        {{view "select" class="form-control" content=filters selectionBinding=filter}}
+        {{view "select" class="form-control"
+                        content=scopes
+                        optionValuePath="content.value"
+                        optionLabelPath="content.label"
+                        value=scope}}
       </div>
     </form>
     <hr />
@@ -16,7 +20,7 @@
       {{#if performingSearch}}
         <li>{{loading-indicator}}</li>
       {{else}}
-        {{#each result in filteredSearchResults}}
+        {{#each result in searchResults}}
           <li class="search-result clearfix">
           {{!-- == TODO: For 2 col layout with library feature later ==
             <li class="search-result row">

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -31,6 +31,32 @@ class Group < ActiveRecord::Base
     class_name: 'GroupMember', dependent: :delete_all
   has_many :stories
 
+  include PgSearch
+  pg_search_scope :instant_search,
+    against: [:name, :bio],
+    using: {
+      tsearch: {
+        prefix: true,
+        normalization: 42,
+        dictionary: 'english'
+      }
+    }
+  pg_search_scope :full_search,
+    # Weight name > bio > about
+    against: { name: 'A', bio: 'B', about: 'C' },
+    using: {
+      tsearch: {
+        prefix: true,
+        normalization: 42,
+        dictionary: 'english'
+      },
+      trigram: {
+        only: [:name, :bio]
+      }
+    },
+    # Combine trigram and tsearch values
+    ranked_by: ':trigram + :tsearch'
+
   has_attached_file :avatar,
     styles: {
       thumb: '190x190#',

--- a/app/models/manga.rb
+++ b/app/models/manga.rb
@@ -32,10 +32,17 @@ class Manga < ActiveRecord::Base
   include Versionable
 
   include PgSearch
-  pg_search_scope :fuzzy_search_by_title, against: [:romaji_title, :english_title],
-    using: {trigram: {threshold: 0.1}}, ranked_by: ":trigram"
-  pg_search_scope :simple_search_by_title, against: [:romaji_title, :english_title],
-    using: {tsearch: {normalization: 10, dictionary: "english"}}, ranked_by: ":tsearch"
+  pg_search_scope :instant_search,
+    against: [ :romaji_title, :english_title ],
+    using: { tsearch: { normalization: 42, dictionary: 'english' } },
+    ranked_by: ':tsearch'
+  pg_search_scope :full_search,
+    against: [ :romaji_title, :english_title ],
+    using: {
+      tsearch: { normalization: 42, dictionary: 'english' },
+      trigram: { threshold: 0.1 }
+    },
+    ranked_by: ':tsearch + :trigram'
 
   extend FriendlyId
   friendly_id :romaji_title, use: [:slugged, :history]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -139,7 +139,7 @@ Hummingbird::Application.routes.draw do
   end
 
   # Search
-  get '/search' => 'search#basic', as: :search
+  get '/search' => 'search#search'
 
   # Imports
   post '/mal_import', to: redirect('/settings/import/myanimelist')

--- a/db/migrate/20150220014905_add_search_indices.rb
+++ b/db/migrate/20150220014905_add_search_indices.rb
@@ -1,0 +1,42 @@
+class AddSearchIndices < ActiveRecord::Migration
+  def up
+    # Anime indices
+    rename_index :anime, :anime_search_index, :anime_trigram_search_index
+    remove_index :anime, name: 'anime_simple_search_index'
+    execute <<-SQL
+      CREATE INDEX anime_text_search_index
+      ON anime
+      USING gin (((to_tsvector('english', coalesce("anime"."title"::text, ''))
+                || to_tsvector('english', coalesce("anime"."alt_title"::text, '')) )))
+    SQL
+
+    # Manga indices
+    rename_index :manga, :manga_fuzzy_search_index, :manga_trigram_search_index
+    remove_index :manga, name: 'manga_simple_search_index'
+    execute <<-SQL
+      CREATE INDEX manga_text_search_index
+      ON manga
+      USING gin (((to_tsvector('english', coalesce("manga"."romaji_title"::text, ''))
+                || to_tsvector('english', coalesce("manga"."english_title"::text, '')) )))
+    SQL
+
+    # Group indices
+    execute <<-SQL
+      CREATE INDEX groups_trigram_search_index
+      ON groups
+      USING gin ((coalesce("groups"."name"::text, '')
+               || ' '
+               || coalesce("groups"."bio"::text, '')) gin_trgm_ops)
+    SQL
+    execute <<-SQL
+      CREATE INDEX groups_text_search_index
+      ON groups
+      USING gin (((setweight(to_tsvector('english', coalesce("groups"."name"::text, '')), 'A')
+                || setweight(to_tsvector('english', coalesce("groups"."bio"::text, '')), 'B')
+                || setweight(to_tsvector('english', coalesce("groups"."about"::text, '')), 'C') )))
+    SQL
+  end
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2415,17 +2415,17 @@ ALTER TABLE ONLY watchlists
 
 
 --
--- Name: anime_search_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: anime_text_search_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE INDEX anime_search_index ON anime USING gin ((((COALESCE((title)::text, ''::text) || ' '::text) || COALESCE((alt_title)::text, ''::text))) gin_trgm_ops);
+CREATE INDEX anime_text_search_index ON anime USING gin (((to_tsvector('english'::regconfig, COALESCE((title)::text, ''::text)) || to_tsvector('english'::regconfig, COALESCE((alt_title)::text, ''::text)))));
 
 
 --
--- Name: anime_simple_search_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: anime_trigram_search_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE INDEX anime_simple_search_index ON anime USING gin (((to_tsvector('simple'::regconfig, COALESCE((title)::text, ''::text)) || to_tsvector('simple'::regconfig, COALESCE((alt_title)::text, ''::text)))));
+CREATE INDEX anime_trigram_search_index ON anime USING gin ((((COALESCE((title)::text, ''::text) || ' '::text) || COALESCE((alt_title)::text, ''::text))) gin_trgm_ops);
 
 
 --
@@ -2433,6 +2433,20 @@ CREATE INDEX anime_simple_search_index ON anime USING gin (((to_tsvector('simple
 --
 
 CREATE UNIQUE INDEX character_mal_id ON characters USING btree (mal_id);
+
+
+--
+-- Name: groups_text_search_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX groups_text_search_index ON groups USING gin ((((setweight(to_tsvector('english'::regconfig, COALESCE((name)::text, ''::text)), 'A'::"char") || setweight(to_tsvector('english'::regconfig, COALESCE((bio)::text, ''::text)), 'B'::"char")) || setweight(to_tsvector('english'::regconfig, COALESCE(about, ''::text)), 'C'::"char"))));
+
+
+--
+-- Name: groups_trigram_search_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX groups_trigram_search_index ON groups USING gin ((((COALESCE((name)::text, ''::text) || ' '::text) || COALESCE((bio)::text, ''::text))) gin_trgm_ops);
 
 
 --
@@ -2975,17 +2989,17 @@ CREATE INDEX index_watchlists_on_user_id_and_status ON watchlists USING btree (u
 
 
 --
--- Name: manga_fuzzy_search_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: manga_text_search_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE INDEX manga_fuzzy_search_index ON manga USING gin ((((COALESCE((romaji_title)::text, ''::text) || ' '::text) || COALESCE((english_title)::text, ''::text))) gin_trgm_ops);
+CREATE INDEX manga_text_search_index ON manga USING gin (((to_tsvector('english'::regconfig, COALESCE((romaji_title)::text, ''::text)) || to_tsvector('english'::regconfig, COALESCE((english_title)::text, ''::text)))));
 
 
 --
--- Name: manga_simple_search_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: manga_trigram_search_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE INDEX manga_simple_search_index ON manga USING gin (((to_tsvector('simple'::regconfig, COALESCE((romaji_title)::text, ''::text)) || to_tsvector('simple'::regconfig, COALESCE((english_title)::text, ''::text)))));
+CREATE INDEX manga_trigram_search_index ON manga USING gin ((((COALESCE((romaji_title)::text, ''::text) || ' '::text) || COALESCE((english_title)::text, ''::text))) gin_trgm_ops);
 
 
 --
@@ -3699,4 +3713,6 @@ INSERT INTO schema_migrations (version) VALUES ('20150112071159');
 INSERT INTO schema_migrations (version) VALUES ('20150129101801');
 
 INSERT INTO schema_migrations (version) VALUES ('20150206031907');
+
+INSERT INTO schema_migrations (version) VALUES ('20150220014905');
 

--- a/lib/tasks/bulk_import_hulu.rake
+++ b/lib/tasks/bulk_import_hulu.rake
@@ -79,7 +79,7 @@ task :bulk_import_hulu, [:shows] => [:environment] do |t, args|
     next import_episodes(anime, show, :exact) unless anime.nil?
 
     ## Trigram
-    options << anime = Anime.fuzzy_search_by_title(show.name).first
+    options << anime = Anime.full_search(show.name).first
     next import_episodes(anime, show, :trigram, anime.pg_search_rank < 0.75) if !anime.nil? && anime.pg_search_rank > 0.66
 
     ## Prefix

--- a/test/models/anime_test.rb
+++ b/test/models/anime_test.rb
@@ -54,7 +54,7 @@ class AnimeTest < ActiveSupport::TestCase
   should validate_uniqueness_of(:title)
 
   test "should implement search scopes" do
-    assert Anime.fuzzy_search_by_title("swodr atr onlien").include?(anime(:sword_art_online))
-    assert Anime.simple_search_by_title("sword art").include?(anime(:sword_art_online))
+    assert Anime.full_search("swodr atr onlien").include?(anime(:sword_art_online))
+    assert Anime.instant_search("sword art").include?(anime(:sword_art_online))
   end
 end

--- a/test/models/manga_test.rb
+++ b/test/models/manga_test.rb
@@ -35,7 +35,7 @@ class MangaTest < ActiveSupport::TestCase
   should have_and_belong_to_many(:genres)
 
   test "should implement search scopes" do
-    assert Manga.fuzzy_search_by_title("monstre").include?(manga(:monster)), "manga fuzzy search"
-    assert Manga.simple_search_by_title("monster").include?(manga(:monster)), "manga simple search"
+    assert Manga.full_search("monstre").include?(manga(:monster)), "manga fuzzy search"
+    assert Manga.instant_search("monster").include?(manga(:monster)), "manga simple search"
   end
 end


### PR DESCRIPTION
Serverside changes:

 * Extract the presenters in serverside `SearchController` into methods which are shared between instant and full searches
 * Fix sorting (by sorting on the `pg_search_rank` column in Rails)
 * Rank everything onto a common scale for all searchable items (0..1 via tsearch normalization mode 32 + 8 + 2)
 * Add a nasty raw-sql hack to rank user results and maintain email searching without exposing too much info about email
   * If we're willing to drop email search (does anyone actually use it?) we can just replace this with just a pg_search on name
 * Rename `fuzzy_search_by_title` and `simple_search_by_title` to `instant_search` and `full_search`, respectively
 * Modify the `full_search` algorithm to just include trigram in the rankings initially
 * Add searching for Groups
 * Updated all indices to match the new search queries

Super Sekrit Internal Unsupported API™ Changes:

 * Change `type` parameter to separate `depth` and `scope` parameters.
   * Maintain `type=full` since it's 3 lines of code and it keeps Tenpenchii and Deadman working for now.  I know we don't officially support third party apps using the internal API, but users blame us anyways if they break so I'd rather not.  Plus Tenpenchii is off Google Play right now so updating might be slower (idk how this stuff works tbh)

Clientside Changes
 * Switch to the modified search endpoints and results
 * Add groups to dropdown
 * Move some of the stuff from the autocomplete to use `{{#link-to}}`
 * Use `transitionToRoute` to get to the `/search` page if you hit enter in the search box
 * Replace `var self = this` with `() => {}` functions where it was easy.

The clientside changes should reduce reboots of the app (searching no longer requires it to reboot) and the search changes should greatly improve result relevance.

I did some rough benchmarks on the search methods too, in development:
Cold Cache: 40ms instant, 600ms full
Hot Cache: 1.1ms instant, 1.5ms full