### PR TITLE
authenticate user when requesting news feed

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -11,6 +11,7 @@ class StoriesController < ApplicationController
       group = Group.find(params[:group_id])
       stories = StoryQuery.find_for_group(group, current_user, params[:page], 30)
     elsif params[:news_feed]
+      authenticate_user!
       stories = NewsFeed.new(current_user).fetch(params[:page] || 1)
     end
 


### PR DESCRIPTION
was there another way for a user to trigger this error without just manually submitting a JSON request?

```
NoMethodError (undefined method `id' for nil:NilClass):
  app/services/news_feed.rb:37:in `initialize'
  app/controllers/stories_controller.rb:14:in `new'
  app/controllers/stories_controller.rb:14:in `index'
  lib/log_before_timeout.rb:14:in `call'
```