### PR TITLE
Fix Genres padding on activity updates

### DIFF
--- a/app/assets/stylesheets/partials/status-panel.css.scss
+++ b/app/assets/stylesheets/partials/status-panel.css.scss
@@ -81,12 +81,15 @@
     @extend .inline-list;
     @extend .secondary;
     @extend .clearfix;
-
+    
     font-size: 14px;
-
-    /* because metamorphs */
-    li:last-of-type:after {
-      content: "";
+    
+    li {
+      padding-right: 0;
+      /* because metamorphs */
+      &:last-of-type:after {
+        content: "";
+      }
     }
   }
 


### PR DESCRIPTION
Issue #417 

---

The in-line list of genres on activity updates has a `padding-right` which makes it look awkward and makes genres use way more space than needed.

With padding:
![](http://a.pomf.se/mibwxl.png)

Without padding:
![](http://a.pomf.se/ujznmz.png)