### PR TITLE
Group search fixes & tests

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -83,7 +83,7 @@ class SearchController < ApplicationController
   end
 
   # Presenters
-  def present_manga(manga, depth=:full)
+  def present_manga(manga)
     {
       type: 'manga',
       title: manga.canonical_title,
@@ -93,7 +93,7 @@ class SearchController < ApplicationController
       rank: manga.pg_search_rank,
       badges: [
         { class: 'manga', content: "Manga" },
-        { class: 'episodes', content: "#{x.volume_count || "?"}vol &bull; #{x.chapter_count || "?"}chap" }
+        { class: 'episodes', content: "#{manga.volume_count || "?"}vol &bull; #{manga.chapter_count || "?"}chap" }
       ]
     }
   end
@@ -120,7 +120,7 @@ class SearchController < ApplicationController
       title: character.name,
       desc: character.description,
       image: character.image,
-      link: character.id,
+      link: character.id.to_s,
       rank: character.pg_search_rank,
       badges: [
         { class: 'character', content: "Character" },

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -6,7 +6,6 @@ class SearchController < ApplicationController
     'manga' => [Manga],
     'groups' => [Group],
     'users' => [User],
-    # Not used yet
     'characters' => [Character]
   }
 
@@ -39,8 +38,8 @@ class SearchController < ApplicationController
           self.send(presenter, x)
         end
 
-        if depth == :instant
-          results.map! { |x| x[:image] = x[:image].url(:small) }
+        if depth == 'instant'
+          results.each { |x| x[:image] = x[:image].url(:small) }
         end
 
         return error! "No results", 404 if results.count == 0

--- a/app/frontend/app/components/waifu-selector.js
+++ b/app/frontend/app/components/waifu-selector.js
@@ -24,7 +24,7 @@ export default Ember.Component.extend({
       },
       queryTokenizer: Bloodhound.tokenizers.whitespace,
       remote: {
-        url: '/search.json?scope=character&depth=instant&query=%QUERY',
+        url: '/search.json?scope=characters&depth=instant&query=%QUERY',
         filter: function(characters) {
           return Ember.$.map(characters.search, function(character) {
             return {

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -1,0 +1,88 @@
+require 'test_helper'
+
+class SearchControllerTest < ActionController::TestCase
+  def setup
+    @controller = SearchController.new
+  end
+
+  test "can present manga" do
+    manga = manga(:monster)
+    manga.define_singleton_method(:pg_search_rank) { 0.9 }
+    presented = @controller.send(:present_manga, manga)
+
+    assert_includes presented, :image
+    assert_equal "manga", presented[:type]
+    [:title, :desc, :link].each { |s|
+      assert_kind_of String, presented[s]
+    }
+    assert_kind_of Float, presented[:rank]
+    assert_kind_of Array, presented[:badges]
+  end
+
+  test "can present anime for a nobody" do
+    anime = anime(:sword_art_online)
+    anime.define_singleton_method(:pg_search_rank) { 0.9 }
+    @controller.define_singleton_method(:current_user) { nil }
+    presented = @controller.send(:present_anime, anime)
+
+    assert_kind_of String, presented[:title]
+  end
+
+  test "can present anime for a user" do
+    anime = anime(:sword_art_online)
+    user = users(:josh)
+    anime.define_singleton_method(:pg_search_rank) { 0.9 }
+    @controller.define_singleton_method(:current_user) { user }
+    presented = @controller.send(:present_anime, anime)
+
+    assert_includes presented, :image
+    assert_equal "anime", presented[:type]
+    [:title, :desc, :link].each { |s|
+      assert_kind_of String, presented[s]
+    }
+    assert_kind_of Float, presented[:rank]
+    assert_kind_of Array, presented[:badges]
+  end
+
+  test "can present character" do
+    character = characters(:kirito)
+    character.define_singleton_method(:pg_search_rank) { 0.9 }
+    presented = @controller.send(:present_character, character)
+
+    assert_includes presented, :image
+    assert_equal "character", presented[:type]
+    [:title, :desc, :link].each { |s|
+      assert_kind_of String, presented[s]
+    }
+    assert_kind_of Float, presented[:rank]
+    assert_kind_of Array, presented[:badges]
+  end
+
+  test "can present group" do
+    group = groups(:gumi)
+    group.define_singleton_method(:pg_search_rank) { 0.9 }
+    presented = @controller.send(:present_group, group)
+
+    assert_includes presented, :image
+    assert_equal "group", presented[:type]
+    [:title, :desc, :link].each { |s|
+      assert_kind_of String, presented[s]
+    }
+    assert_kind_of Float, presented[:rank]
+    assert_kind_of Array, presented[:badges]
+  end
+
+  test "can present user" do
+    user = users(:josh)
+    user.define_singleton_method(:pg_search_rank) { 0.9 }
+    presented = @controller.send(:present_user, user)
+
+    assert_includes presented, :image
+    assert_equal "user", presented[:type]
+    [:title, :desc, :link].each { |s|
+      assert_kind_of String, presented[s]
+    }
+    assert_kind_of Float, presented[:rank]
+    assert_kind_of Array, presented[:badges]
+  end
+end

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -5,6 +5,35 @@ class SearchControllerTest < ActionController::TestCase
     @controller = SearchController.new
   end
 
+  test "scoped search works" do
+    get :search, format: :json, scope: 'anime', depth: 'full', query: 'sword art online'
+    assert_response :ok
+
+    results = JSON.parse(@response.body)['search']
+    assert_equal "Sword Art Online", results[0]['title']
+  end
+
+  test "deprecated type=full search works" do
+    get :search, format: :json, type: 'full', query: 'sword art online'
+    assert_response :ok
+
+    results = JSON.parse(@response.body)['search']
+    assert_equal "Sword Art Online", results[0]['title']
+  end
+
+  test "element search works" do
+    get :search, format: :json, scope: 'anime', depth: 'element', query: 'sword art online'
+    assert_response :ok
+
+    results = JSON.parse(@response.body)
+    assert_equal "Sword Art Online", results.values.first.first['canonical_title']
+  end
+
+  test "element search for unimplemented scopes fails" do
+    get :search, format: :json, scope: 'characters', depth: 'element', query: 'sword art online'
+    assert_response :not_implemented
+  end
+
   test "can present manga" do
     manga = manga(:monster)
     manga.define_singleton_method(:pg_search_rank) { 0.9 }

--- a/test/fixtures/characters.yml
+++ b/test/fixtures/characters.yml
@@ -1,0 +1,20 @@
+# == Schema Information
+#
+# Table name: characters
+#
+#  id                 :integer          not null, primary key
+#  name               :string(255)
+#  description        :text
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  mal_id             :integer
+#  image_file_name    :string(255)
+#  image_content_type :string(255)
+#  image_file_size    :integer
+#  image_updated_at   :datetime
+#  slug               :string(255)
+#
+
+kirito:
+  name: Kazuto Kirigaya
+  description: Basically video game jesus.  Fucks mad bitches.


### PR DESCRIPTION
I'd meant to add thorough tests once I confirmed that the ugly presenter methods was the route we wanted to take, so here they are now.  This should confirm functionality for the most part.

Also fixed the leftover issue I missed when I blind-fixed the manga presenter as well as the image size adjustment for instant search (it was previously giving `:original` size for instant search which would result in excessive bandwidth usage)

Should also fix the unreported (for obvious reasons) issue with onboarding "element" search.  Maybe.  I'm not 100% certain of this due to unfamiliarity with the expected JSON response.  I don't think it will work, but I also don't know how to fix it.

Relevant is the JSON it produces: 

```json
{
    "search": [
        {
            "age_rating": "R17+", 
            "age_rating_guide": "Violence, Profanity", 
            ...
        }
    ]
}
```

Won't ED be confused by the `search` key?  I don't even know where it gets the `search` key from...