### PR TITLE
Fix waifu selector dropdown titles

### DIFF
--- a/app/frontend/app/components/waifu-selector.js
+++ b/app/frontend/app/components/waifu-selector.js
@@ -28,7 +28,7 @@ export default Ember.Component.extend({
         filter: function(characters) {
           return Ember.$.map(characters.search, function(character) {
             return {
-              value: character.name,
+              value: character.title,
               char_id: character.link
             };
           });


### PR DESCRIPTION
Not much to say about this. This fixes the waifu select drop down when a user is editing his profile details.

_waifu still broken apparently.  probably a typo went unnoticed in there_
~ @NuckChorris 

