### PR TITLE
First Notification refactoring

### DIFF
--- a/app/assets/stylesheets/base/layout.css.scss
+++ b/app/assets/stylesheets/base/layout.css.scss
@@ -171,7 +171,7 @@ html { overflow-y: auto; }
 
       a {
         width: 100% !important;
-        padding: 15px !important;
+        padding: 8px 15px !important;
 
         &:hover {
           color: #999999 !important;

--- a/app/assets/stylesheets/partials/notification.css.scss
+++ b/app/assets/stylesheets/partials/notification.css.scss
@@ -44,7 +44,7 @@
 .all-notifications {
   .notification-item {
     @extend .row;
-    padding: 10px 0;
+    padding: 10px 0 10px 10px;
     border-bottom: 1px solid #ddd;
 
     .content, .time {
@@ -79,7 +79,7 @@
 
     &.new {
       border-left: 10px solid #f7edda;
-      margin-left: -10px;
+      padding-left: 0px;
     }
 
     &:hover {

--- a/app/assets/stylesheets/partials/notification.css.scss
+++ b/app/assets/stylesheets/partials/notification.css.scss
@@ -42,8 +42,57 @@
 }
 
 .all-notifications {
-  .notification {
-    margin: 10px;
-    padding: 10px;
+  .notification-item {
+    @extend .row;
+    padding: 10px 0;
+    border-bottom: 1px solid #ddd;
+
+    .content, .time {
+      line-height: 46px;
+    }
+
+    .notification-title {
+      @extend .col-xs-8;
+      .avatar {
+        @extend .col-xs-1;
+        padding: 0;
+      }
+
+      .content {
+        @extend .col-xs-11;
+
+        .who {
+          font-weight: bold;
+        }
+      }
+    }
+
+    .notification-options {
+      @extend .col-xs-4;
+
+      .mark-read {
+        opacity: 0;
+        margin-top: 10px;
+        transition: opacity 0.3s ease-in-out;
+      }
+    }
+
+    &.new {
+      border-left: 10px solid #f7edda;
+      margin-left: -10px;
+    }
+
+    &:hover {
+      .mark-read {
+        opacity: 1;
+        transition: opacity 0.3s ease-in-out;
+      }
+    }
   }
+
 }
+
+.mark-read-all {
+  margin-top: 15px;
+}
+

--- a/app/assets/stylesheets/partials/notification.css.scss
+++ b/app/assets/stylesheets/partials/notification.css.scss
@@ -60,6 +60,7 @@
 
       .content {
         @extend .col-xs-11;
+        color: #000;
 
         .who {
           font-weight: bold;

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -29,4 +29,14 @@ class NotificationsController < ApplicationController
       end
     end
   end
+
+  def mark_read
+    if params[:notification_id].nil?
+      Notification.where(user_id: current_user).update_all seen: true
+    else
+      Notification.where(id: params[:notification_id], user_id: current_user).update_all seen: true
+    end
+
+    render json: { success: true }
+  end
 end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -3,15 +3,15 @@ class NotificationsController < ApplicationController
 
   def index
     hide_cover_image
-    @notifications = Notification.where(user_id: current_user).order("created_at DESC").includes(:source, source: :target).limit(10)
+    @notifications = Notification.where(user_id: current_user).order("created_at DESC").includes(:source, source: :target).limit(20)
 
     respond_to do |format|
       format.json { render json: @notifications, each_serializer: NotificationSerializer }
       format.html { render_ember }
     end
     @notifications.where(seen: false).each {|x| x.update_column :seen, true }
-    if @notifications.count > 10
-      Notification.where(user_id: current_user, seen: true).order("created_at").limit(@notifications.count - 10).each {|x| x.destroy }
+    if @notifications.count > 20
+      Notification.where(user_id: current_user, seen: true).order("created_at").limit(@notifications.count - 20).each {|x| x.destroy }
     end
     Notification.uncache_notification_cache(current_user.id)
   end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -9,7 +9,6 @@ class NotificationsController < ApplicationController
       format.json { render json: @notifications, each_serializer: NotificationSerializer }
       format.html { render_ember }
     end
-    @notifications.where(seen: false).each {|x| x.update_column :seen, true }
     if @notifications.count > 20
       Notification.where(user_id: current_user, seen: true).order("created_at").limit(@notifications.count - 20).each {|x| x.destroy }
     end

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -22,7 +22,6 @@ class StoriesController < ApplicationController
 
     if user_signed_in? and current_user == story.user
       Notification.where(user: story.user, notification_type: "profile_comment", seen: false, source_id: story.id).update_all seen: true
-      # TODO: Mark post replies as read as well, when opening the permalink!
     end
 
     respond_to do |format|

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -19,6 +19,12 @@ class StoriesController < ApplicationController
 
   def show
     story = StoryQuery.find_by_id(params[:id], current_user)
+
+    if user_signed_in? and current_user == story.user
+      Notification.where(user: story.user, notification_type: "profile_comment", seen: false, source_id: story.id).update_all seen: true
+      # TODO: Mark post replies as read as well, when opening the permalink!
+    end
+
     respond_to do |format|
       format.json { render json: story }
       format.html do

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -47,12 +47,6 @@ class UsersController < ApplicationController
       return redirect_to user_path(@user), status: :moved_permanently
     end
 
-    if user_signed_in? and current_user == @user
-      # Clear notifications if the current user is viewing his/her feed.
-      # TODO This needs to be moved elsewhere.
-      Notification.where(user: @user, notification_type: "profile_comment", seen: false).update_all seen: true
-    end
-
     respond_to do |format|
       format.html do
         preload_to_ember! @user

--- a/app/frontend/app/controllers/header.js
+++ b/app/frontend/app/controllers/header.js
@@ -20,7 +20,7 @@ export default Ember.Controller.extend(HasCurrentUser, {
   unreadNotificationsCount: Ember.computed.alias('unreadNotifications.length'),
   hasUnreadNotifications: Ember.computed.notEmpty('unreadNotifications'),
   limitedNotifications: function () {
-    return this.get('notifications').slice(0, 3);
+    return this.get('notifications').slice(0, 6);
   }.property('notifications.@each'),
 
   blotter: PreloadStore.get('blotter'),

--- a/app/frontend/app/controllers/notifications.js
+++ b/app/frontend/app/controllers/notifications.js
@@ -11,12 +11,36 @@ export default Ember.ArrayController.extend({
 
 
   actions: {
-    markAsRead: function(notifId){
+    markAsRead: function(notif){
+      Messenger().run({
+        action: $.ajax,
 
+        successMessage: () => {
+          notif.set('seen', true);
+          return 'Marked notification as read.';
+        },
+        errorMessage: 'Error marking notification as read.',
+        progressMessage: 'Marking notification as read...'
+      }, {
+        url: '/notifications/mark_read/'+notif.get('id')
+      });
     },
 
     markAllAsRead: function(){
-      
+      Messenger().run({
+        action: $.ajax,
+
+        successMessage: () => {
+          this.store.find('notification').forEach(function(notif){
+            notif.set('seen', true);
+          });
+          return 'Marked all notifications as read.';
+        },
+        errorMessage: 'Error marking notifications as read.',
+        progressMessage: 'Marking notifications as read...'
+      }, {
+        url: '/notifications/mark_read'
+      });
     }
   }
 });

--- a/app/frontend/app/controllers/notifications.js
+++ b/app/frontend/app/controllers/notifications.js
@@ -7,5 +7,16 @@ export default Ember.ArrayController.extend({
   },
 
   sortProperties: ['createdAt'],
-  sortAscending: false
+  sortAscending: false,
+
+
+  actions: {
+    markAsRead: function(notifId){
+
+    },
+
+    markAllAsRead: function(){
+      
+    }
+  }
 });

--- a/app/frontend/app/controllers/notifications.js
+++ b/app/frontend/app/controllers/notifications.js
@@ -9,6 +9,9 @@ export default Ember.ArrayController.extend({
   sortProperties: ['createdAt'],
   sortAscending: false,
 
+  unreadNotifications: Ember.computed.filterBy('content', 'seen', false),
+  hasUnreadNotifications: Ember.computed.gte('unreadNotifications.length', 1),
+
 
   actions: {
     markAsRead: function(notif){

--- a/app/frontend/app/controllers/notifications.js
+++ b/app/frontend/app/controllers/notifications.js
@@ -1,4 +1,6 @@
 import Ember from 'ember';
+import ajax from 'ic-ajax';
+/* global Messenger */
 
 export default Ember.ArrayController.extend({
   init: function(){
@@ -15,24 +17,28 @@ export default Ember.ArrayController.extend({
 
   actions: {
     markAsRead: function(notif){
-      Messenger().run({
-        action: $.ajax,
-
+      Messenger().expectPromise(function() {
+        return ajax({
+          type: 'POST',
+          url: '/notifications/mark_read/'+notif.get('id')
+        });
+      }, {
         successMessage: () => {
           notif.set('seen', true);
           return 'Marked notification as read.';
         },
         errorMessage: 'Error marking notification as read.',
         progressMessage: 'Marking notification as read...'
-      }, {
-        url: '/notifications/mark_read/'+notif.get('id')
       });
     },
 
     markAllAsRead: function(){
-      Messenger().run({
-        action: $.ajax,
-
+      Messenger().expectPromise(function() {
+        return ajax({
+          type: 'POST',
+          url: '/notifications/mark_read/'
+        });
+      }, {
         successMessage: () => {
           this.store.find('notification').forEach(function(notif){
             notif.set('seen', true);
@@ -41,8 +47,6 @@ export default Ember.ArrayController.extend({
         },
         errorMessage: 'Error marking notifications as read.',
         progressMessage: 'Marking notifications as read...'
-      }, {
-        url: '/notifications/mark_read'
       });
     }
   }

--- a/app/frontend/app/helpers/notification-message.js
+++ b/app/frontend/app/helpers/notification-message.js
@@ -19,7 +19,7 @@ export function notificationMessage(notificationObject) {
 
   if(messageStore[messageType] === undefined) { return "A cat probably ate this notification!"; }
   var msg = messageStore[messageType].replace('<user>',
-    '<span class="who">'+notificationObject.get('source.user.username')+'</span>');
+    '<span class="who">'+notificationObject.get('sourceUser.username')+'</span>');
 
   return new Ember.Handlebars.SafeString(msg);
 }

--- a/app/frontend/app/helpers/notification-message.js
+++ b/app/frontend/app/helpers/notification-message.js
@@ -1,0 +1,27 @@
+import Ember from 'ember';
+
+export function notificationMessage(notificationObject) {
+  if(notificationObject === undefined) { return; }
+
+  var messageType = notificationObject.get('notificationType');
+  var messageStore = {
+
+    /* Old notification types! */
+    profile_comment: '<user> wrote a post on your feed.',
+    comment_reply: '<user> wrote a reply to your comment.',
+
+    feed_post:          '<user> wrote a post on your feed.',
+    feed_post_comment:  '<user> wrote a comment to your feed post.',
+    feed_post_reply:    '<user> commented on a feed post you commented on.',
+    feed_post_like:     '<user> liked your feed post.',
+    user_follow:        '<user> followed you.' 
+  }
+
+  if(messageStore[messageType] === undefined) { return "A cat probably ate this notification!" }
+  var msg = messageStore[messageType].replace('<user>',
+    '<span class="who">'+notificationObject.get('source.user.username')+'</span>');
+
+  return new Ember.Handlebars.SafeString(msg);
+}
+
+export default Ember.Handlebars.makeBoundHelper(notificationMessage);

--- a/app/frontend/app/helpers/notification-message.js
+++ b/app/frontend/app/helpers/notification-message.js
@@ -14,10 +14,10 @@ export function notificationMessage(notificationObject) {
     feed_post_comment:  '<user> wrote a comment to your feed post.',
     feed_post_reply:    '<user> commented on a feed post you commented on.',
     feed_post_like:     '<user> liked your feed post.',
-    user_follow:        '<user> followed you.' 
-  }
+    user_follow:        '<user> followed you.'
+  };
 
-  if(messageStore[messageType] === undefined) { return "A cat probably ate this notification!" }
+  if(messageStore[messageType] === undefined) { return "A cat probably ate this notification!"; }
   var msg = messageStore[messageType].replace('<user>',
     '<span class="who">'+notificationObject.get('source.user.username')+'</span>');
 

--- a/app/frontend/app/templates/_notification.hbs
+++ b/app/frontend/app/templates/_notification.hbs
@@ -4,16 +4,7 @@
       {{avatar sourceUser 'thumb_small'}}
     </div>
     <div class="content">
-      <span class="who">
-        {{sourceUser.username}}
-      </span>
-
-      {{#if isProfileComment}}
-        wrote a comment on your profile.
-      {{/if}}
-      {{#if isCommentReply}}
-        wrote a reply to your comment.
-      {{/if}}
+      {{notification-message this}}
 
       <div class="time">{{time-ago time=createdAt}}</div>
     </div>

--- a/app/frontend/app/templates/header/notifications.hbs
+++ b/app/frontend/app/templates/header/notifications.hbs
@@ -10,7 +10,7 @@
     {{#each limitedNotifications}}
       {{partial "notification"}}
     {{else}}
-      <li class="no-notifications">
+      <li class="notification no-notifications">
         <span>You don't have any notifications yet.</span>
       </li>
     {{/each}}

--- a/app/frontend/app/templates/notifications.hbs
+++ b/app/frontend/app/templates/notifications.hbs
@@ -17,17 +17,21 @@
               </div>
             </div>
             <div class="notification-options">
-              <div class="mark-read pull-right btn btn-default btn-xs" {{action 'markAsRead' notification}}>
-                <i class="fa fa-check"></i>
-              </div>
+              {{#unless notification.seen}}
+                <div class="mark-read pull-right btn btn-default btn-xs" {{action 'markAsRead' notification}}>
+                  <i class="fa fa-check"></i>
+                </div>
+              {{/unless}}
               <div class="time">{{time-ago time=createdAt}}</div>
             </div>
           </div>
         {{/each}}
       </ul>
-      <div class="mark-read-all pull-right btn btn-default" {{action 'markAllAsRead'}}>
-        <i class="fa fa-check"></i> Mark all as read
-      </div>
+      {{#if hasUnreadNotifications}}
+        <div class="mark-read-all pull-right btn btn-default" {{action 'markAllAsRead'}}>
+          <i class="fa fa-check"></i> Mark all as read
+        </div>
+      {{/if}}
     </div>
   </div>
 </div>

--- a/app/frontend/app/templates/notifications.hbs
+++ b/app/frontend/app/templates/notifications.hbs
@@ -5,16 +5,14 @@
         {{#each notification in model}}
           <div {{bind-attr class=":notification-item notification.seen::new"}}>
             <div class="notification-title">
-              <div class="avatar">
-                {{avatar notification.sourceUser 'thumb_small'}}
-              </div>
-              <div class="content">
-                <span class="who">
-                  {{notification.sourceUser.username}}
-                </span>
-
-                is awesome.
-              </div>
+              <a {{bind-attr href=notification.link}}>
+                <div class="avatar">
+                  {{avatar notification.sourceUser 'thumb_small'}}
+                </div>
+                <div class="content">
+                  {{notification-message notification}}
+                </div>
+              </a>
             </div>
             <div class="notification-options">
               {{#unless notification.seen}}

--- a/app/frontend/app/templates/notifications.hbs
+++ b/app/frontend/app/templates/notifications.hbs
@@ -1,11 +1,33 @@
 <div class="container">
   <div class="row" style="margin-top: 50px">
-    <div class="col-md-6 col-md-offset-3">
+    <div class="col-md-10 col-md-offset-1">
       <ul class="all-notifications">
-        {{#each}}
-          {{partial "notification"}}
+        {{#each notification in model}}
+          <div {{bind-attr class=":notification-item notification.read::new"}}>
+            <div class="notification-title">
+              <div class="avatar">
+                {{avatar notification.sourceUser 'thumb_small'}}
+              </div>
+              <div class="content">
+                <span class="who">
+                  {{notification.sourceUser.username}}
+                </span>
+
+                is awesome.
+              </div>
+            </div>
+            <div class="notification-options">
+              <div class="mark-read pull-right btn btn-default btn-xs" {{action 'markAsRead' notification.id}}>
+                <i class="fa fa-check"></i>
+              </div>
+              <div class="time">{{time-ago time=createdAt}}</div>
+            </div>
+          </div>
         {{/each}}
       </ul>
+      <div class="mark-read-all pull-right btn btn-default" {{action 'markAllAsRead'}}>
+        <i class="fa fa-check"></i> Mark all as read
+      </div>
     </div>
   </div>
 </div>

--- a/app/frontend/app/templates/notifications.hbs
+++ b/app/frontend/app/templates/notifications.hbs
@@ -3,7 +3,7 @@
     <div class="col-md-10 col-md-offset-1">
       <ul class="all-notifications">
         {{#each notification in model}}
-          <div {{bind-attr class=":notification-item notification.read::new"}}>
+          <div {{bind-attr class=":notification-item notification.seen::new"}}>
             <div class="notification-title">
               <div class="avatar">
                 {{avatar notification.sourceUser 'thumb_small'}}
@@ -17,7 +17,7 @@
               </div>
             </div>
             <div class="notification-options">
-              <div class="mark-read pull-right btn btn-default btn-xs" {{action 'markAsRead' notification.id}}>
+              <div class="mark-read pull-right btn btn-default btn-xs" {{action 'markAsRead' notification}}>
                 <i class="fa fa-check"></i>
               </div>
               <div class="time">{{time-ago time=createdAt}}</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,7 +49,7 @@ Hummingbird::Application.routes.draw do
   get '/users/sign_in', to: redirect('/sign-in')
   get '/users/sign_up', to: redirect('/sign-up')
 
-  get '/notifications/mark_read(/:notification_id)' => 'notifications#mark_read'
+  post '/notifications/mark_read(/:notification_id)' => 'notifications#mark_read'
   resources :notifications, only: [:index, :show]
 
   namespace :community do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,6 +49,7 @@ Hummingbird::Application.routes.draw do
   get '/users/sign_in', to: redirect('/sign-in')
   get '/users/sign_up', to: redirect('/sign-up')
 
+  get '/notifications/mark_read(/:notification_id)' => 'notifications#mark_read'
   resources :notifications, only: [:index, :show]
 
   namespace :community do


### PR DESCRIPTION
This pull request contains all the frontend changes for the basic new notification system. This includes:  
- A new notification page that displays all user notification (maximum now is 20)
 - Allows user to mark either one or all notification(s) as read.
- The notification tray has a bit less padding and will now display up to 6 notifications.

![Image of Notification page](http://a.pomf.se/kkpkpt.jpg)

The new notification system handles notification messages with a message helper, the following _templates_ are currently implemented:
- feed_post (_old profile_comment_)
- feed_post_comment (_old comment_reply_)
- feed_post_reply
- feed_post_like
- user_follow

This will only add the needed frontend placeholders, no backend changes.
It will be deployed in a first step of the refactoring to get the new notifications page online and add the mark as read functionality. Any backend changes necessairy will be done later on.