### PR TITLE
Fix various bugs introduced by search refactoring

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -50,7 +50,7 @@ class SearchController < ApplicationController
         end
 
         if depth == 'instant'
-          results.each { |x| x[:image] = x[:image].url(:small) }
+          results.each { |x| x[:image] = x[:image].url(:medium) }
         end
 
         return error! "No results", 404 if results.count == 0

--- a/app/frontend/app/components/favorite-search.js
+++ b/app/frontend/app/components/favorite-search.js
@@ -30,10 +30,10 @@ export default Ember.Component.extend({
         return x.get('item.id');
       });
 
-      var isInFavs = favs.contains(item.slug);
+      var isInFavs = favs.contains(item.link);
       var isTypeOk = ( item.type === self.get('type') );
       
-      return ( !isInFavs && isTypeOk ); 
+      return ( !isInFavs && isTypeOk );
     });
   }.property('searchResults.@each'),
 
@@ -63,7 +63,7 @@ export default Ember.Component.extend({
       store.find('user', cuser.get('id')).then(function(user){
         newFav.set('user', user);
 
-        store.find(media.type, media.slug).then(function(item){
+        store.find(media.type, media.link).then(function(item){
           newFav.set('item', item);
           newFav.save();
           self.sendAction('action', newFav);

--- a/app/frontend/app/components/waifu-selector.js
+++ b/app/frontend/app/components/waifu-selector.js
@@ -28,7 +28,7 @@ export default Ember.Component.extend({
         filter: function(characters) {
           return Ember.$.map(characters.search, function(character) {
             return {
-              value: character.name,
+              value: character.title,
               char_id: character.link
             };
           });

--- a/app/frontend/app/models/anime.js
+++ b/app/frontend/app/models/anime.js
@@ -25,6 +25,10 @@ export default Media.extend(ModelCurrentUser, {
     return this.get('ageRating') === "R18+" || this.get('ageRating') === "R17+";
   }.property('ageRating'),
 
+  posterImageThumb: function(){
+    return this.get('posterImage').replace("/large/", "/medium/");
+  }.property('posterImage'),
+
   displayTitle: function() {
     var currentUser, pref, title;
     currentUser = this.get('currentUser');

--- a/app/frontend/app/templates/components/favorite-container.hbs
+++ b/app/frontend/app/templates/components/favorite-container.hbs
@@ -21,7 +21,7 @@
             {{#if isEditing}}
               <li class="grid-list grid-draggable clearfix" {{bind-attr data-id=favorite.id}}>
                 {{!-- <span class="grid-position">{{favorite.favRank}}</span> --}}
-                <img class="grid-list-thumb" {{bind-attr src=favorite.item.posterImage}} />
+                <img class="grid-list-thumb" {{bind-attr src=favorite.item.posterImageThumb}} />
                 <span class="grid-list-title">{{favorite.item.displayTitle}}</span>
                 <span class="grid-position" {{action 'deleteFavorite' favorite}}><i class="fa fa-times-circle"></i></span>
               </li>

--- a/app/frontend/app/templates/components/instant-search.hbs
+++ b/app/frontend/app/templates/components/instant-search.hbs
@@ -7,7 +7,7 @@
     <ul class="search-dropdown">
       {{#each result in searchResults}}
         <li class="search-result">
-          {{#link-to result.type result.link title="result.title"}}
+          {{#link-to result.type result.link title=result.title}}
             <div class="search-result-thumb">
               <img {{bind-attr src="result.image"}} />
             </div>


### PR DESCRIPTION
This will fix the follwoing things that **@NuckChorris broke™**

- Fix search in favorites adding wrong anime/manga.
- Quick fix for not using large images in fav edit preview.
- Not display already faved media in favorite box search
- Use medium images for search results (smaller images are broken)
 - Yes, this is a very hacky solution here, we should maybe finally sort out while images break in this case.
- Fix title of search results in the header instant search.