### PR TITLE
Fix Facebook disconnection & Group stories

### DIFF
--- a/app/frontend/app/templates/settings.hbs
+++ b/app/frontend/app/templates/settings.hbs
@@ -148,7 +148,9 @@
         <div class="panel-heading"><h3 class="panel-title">Connections</h3></div>
         <div class="panel-body">
           {{#if currentUser.hasFacebook }}
-            <a {{bind-attr href=facebookDisconnectUrl}} class="btn btn-danger fb-connect">Disconnect from Facebook</a>
+            <form method="POST" {{bind-attr action=facebookDisconnectUrl}}>
+              <button type="submit" class="btn fb-connect">Disconnect from Facebook</button>
+            </form>
           {{else}}
             <a href="/users/auth/facebook" class="btn fb-connect">Connect to Facebook</a>
           {{/if}}

--- a/app/services/news_feed.rb
+++ b/app/services/news_feed.rb
@@ -76,7 +76,7 @@ class NewsFeed
   def add!(story)
     add_story = false
     if story.story_type == "comment"
-      if @user == story.target or @user.following.include?(story.target)
+      if story.group.present? || @user == story.target || @user.following.include?(story.target)
         add_story = true
       end
     elsif story.story_type != "followed"


### PR DESCRIPTION
Fixes Facebook disconnection expecting a POST but using a GET on the frontend, also fixes an issue where group stories weren't being added to the news feed of a group member if they didn't follow that user.