### PR TITLE
Make joining groups default to accepted

### DIFF
--- a/app/controllers/group_members_controller.rb
+++ b/app/controllers/group_members_controller.rb
@@ -19,8 +19,11 @@ class GroupMembersController < ApplicationController
     return error! "Wrong user", 403 if user.nil? || current_user != user
     return error! "Already in group", :conflict if GroupMember.exists?(membership_hash.slice('user_id', 'group_id'))
 
+    group = Group.find(membership_hash['group_id'])
+
     membership = GroupMember.create!(
-      group: Group.find(membership_hash['group_id']),
+      group: group,
+      pending: !group.public?,
       user: user
     )
     render json: membership, status: :created

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -112,6 +112,10 @@ class Group < ActiveRecord::Base
     has_admin?(user) || has_mod?(user)
   end
 
+  def public?
+    true
+  end
+
   def self.new_with_admin(params, admin)
     group = Group.new(params)
     group.members.build(


### PR DESCRIPTION
I've put in a `Group#public?` method on the grounds that eventually we'll want an actual enum behind it and allow for non-public groups (I guess probably private and invite-only)