### PR TITLE
Use MessageFormatter to format the user and group about text

### DIFF
--- a/app/frontend/app/models/group.js
+++ b/app/frontend/app/models/group.js
@@ -5,12 +5,14 @@ export default DS.Model.extend(ModelTruncatedDetails, {
   name: DS.attr('string'),
   bio: DS.attr('string'),
   about: DS.attr('string'),
+  aboutFormatted: DS.attr('string'),
   coverImageUrl: DS.attr('string'),
   avatarUrl: DS.attr('string'),
   memberCount: DS.attr('number'),
   members: DS.hasMany('group-member'),
   currentMember: DS.belongsTo('group-member'),
 
+  aboutDisplay: Ember.computed.any('aboutFormatted', 'about'),
   coverImageStyle: function() {
     return "background: url(" + this.get('coverImageUrl') + ") center;";
   }.property('coverImageUrl'),

--- a/app/frontend/app/models/user.js
+++ b/app/frontend/app/models/user.js
@@ -8,6 +8,7 @@ export default DS.Model.extend(ModelTruncatedDetails, {
   avatarTemplate: DS.attr('string'),
   bio: DS.attr('string'),
   about: DS.attr('string'),
+  aboutFormatted: DS.attr('string'),
   location: DS.attr('string'),
   website: DS.attr('string'),
   waifu: DS.attr('string'),
@@ -21,6 +22,8 @@ export default DS.Model.extend(ModelTruncatedDetails, {
   isPro: DS.attr('boolean'),
   followerCount: DS.attr('number'),
   followingCount: DS.attr('number'),
+
+  aboutDisplay: Ember.computed.any('aboutFormatted', 'about'),
 
   avatarUrl: function() {
     return this.get("avatarTemplate").replace('{size}', 'thumb');

--- a/app/frontend/app/templates/group/index.hbs
+++ b/app/frontend/app/templates/group/index.hbs
@@ -25,7 +25,7 @@
             </div>
             {{textarea class="edit-bio" rows="3" placeholder="Tell us about your group." value=group.truncatedAbout}}
           {{else}}
-            <p class="about">{{group.about}}</p>
+            <p class="about">{{group.aboutDisplay}}</p>
           {{/if}}
         </div>
       </div>

--- a/app/frontend/app/templates/user/index.hbs
+++ b/app/frontend/app/templates/user/index.hbs
@@ -50,7 +50,7 @@
             </div>
           {{else}}
             {{#if hasAboutSection}}
-              <p class="about"> {{user.about}}</p>
+              <p class="about"> {{user.aboutDisplay}}</p>
               <div class="user-interests">
                 <ul>
                   <li>

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -19,6 +19,7 @@
 #  created_at               :datetime
 #  updated_at               :datetime
 #  avatar_processing        :boolean
+#  about_formatted          :text
 #
 
 class Group < ActiveRecord::Base
@@ -128,5 +129,11 @@ class Group < ActiveRecord::Base
 
   def self.trending(count = 10)
     TrendingGroups.list(count)
+  end
+
+  before_save do
+    if about_changed?
+      self.about_formatted = MessageFormatter.format_message about
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,6 +62,7 @@
 #  stripe_token                :string(255)
 #  pro_membership_plan_id      :integer
 #  stripe_customer_id          :string(255)
+#  about_formatted             :text
 #
 
 class User < ActiveRecord::Base
@@ -400,6 +401,10 @@ class User < ActiveRecord::Base
         break unless User.where(authentication_token: token).first
       end
       self.authentication_token = token
+    end
+
+    if about_changed?
+      self.about_formatted = MessageFormatter.format_message about
     end
 
     if waifu_char_id != '0000' and changed_attributes['waifu_char_id']

--- a/app/serializers/group_serializer.rb
+++ b/app/serializers/group_serializer.rb
@@ -2,7 +2,7 @@ class GroupSerializer < ActiveModel::Serializer
   embed :ids, include: true
 
   attributes :id, :name, :avatar_url, :cover_image_url, :bio,
-    :about, :member_count
+    :about, :member_count, :about_formatted
 
   has_one :current_member, root: :group_members
   has_many :members, root: :group_members

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -2,7 +2,8 @@ class UserSerializer < ActiveModel::Serializer
   attributes :id, :cover_image_url, :avatar_template, :rating_type, :bio,
     :about, :is_followed, :title_language_preference, :location, :website,
     :waifu, :waifu_or_husbando, :waifu_slug, :waifu_char_id, :last_sign_in_at,
-    :current_sign_in_at, :is_admin, :following_count, :follower_count, :is_pro
+    :current_sign_in_at, :is_admin, :following_count, :follower_count, :is_pro,
+    :about_formatted
 
   def id
     object.name

--- a/db/migrate/20150305204429_add_about_formatted_to_users.rb
+++ b/db/migrate/20150305204429_add_about_formatted_to_users.rb
@@ -1,0 +1,6 @@
+class AddAboutFormattedToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :about_formatted, :text
+    add_column :groups, :about_formatted, :text
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -869,7 +869,8 @@ CREATE TABLE groups (
     confirmed_members_count integer DEFAULT 0,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
-    avatar_processing boolean
+    avatar_processing boolean,
+    about_formatted text
 );
 
 
@@ -1582,7 +1583,8 @@ CREATE TABLE users (
     pro_expires_at timestamp without time zone,
     stripe_token character varying(255),
     pro_membership_plan_id integer,
-    stripe_customer_id character varying(255)
+    stripe_customer_id character varying(255),
+    about_formatted text
 );
 
 
@@ -3715,4 +3717,6 @@ INSERT INTO schema_migrations (version) VALUES ('20150129101801');
 INSERT INTO schema_migrations (version) VALUES ('20150206031907');
 
 INSERT INTO schema_migrations (version) VALUES ('20150220014905');
+
+INSERT INTO schema_migrations (version) VALUES ('20150305204429');
 

--- a/test/fixtures/groups.yml
+++ b/test/fixtures/groups.yml
@@ -19,6 +19,7 @@
 #  created_at               :datetime
 #  updated_at               :datetime
 #  avatar_processing        :boolean
+#  about_formatted          :text
 #
 
 gumi:

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -62,6 +62,7 @@
 #  stripe_token                :string(255)
 #  pro_membership_plan_id      :integer
 #  stripe_customer_id          :string(255)
+#  about_formatted             :text
 #
 
 vikhyat:

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -19,6 +19,7 @@
 #  created_at               :datetime
 #  updated_at               :datetime
 #  avatar_processing        :boolean
+#  about_formatted          :text
 #
 
 require 'test_helper'

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -62,6 +62,7 @@
 #  stripe_token                :string(255)
 #  pro_membership_plan_id      :integer
 #  stripe_customer_id          :string(255)
+#  about_formatted             :text
 #
 
 require 'test_helper'


### PR DESCRIPTION
Exactly as the title says, this uses the `MessageFormatter` service to expose formatting capabilities in the about section.  I haven't really tested it, because I'm just doing this between things today.  Merge with caution.

This should do [Convert newlines in "about" section to &lt;br&gt; tags](https://www.pivotaltracker.com/story/show/88584772)