### PR TITLE
Small tweaks

### DIFF
--- a/app/assets/stylesheets/partials/user-cover-image.css.scss
+++ b/app/assets/stylesheets/partials/user-cover-image.css.scss
@@ -289,6 +289,11 @@
         background: rgba(255,255,255,.3);
       }
     }
+    @media (max-width: 694px) {
+      padding: 7px 20px;
+      overflow: auto;
+      bottom: 0;
+    }
   }
 }
 

--- a/app/assets/stylesheets/partials/user-index.css.scss
+++ b/app/assets/stylesheets/partials/user-index.css.scss
@@ -55,6 +55,9 @@
 
     // Hide less important links on mobile
     @media (max-width: 560px) {
+      white-space: nowrap;
+      overflow: auto;
+
       .reviews-link, .lists-link {
         display: none;
       }

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -57,6 +57,7 @@ class AdminController < ApplicationController
     stats[:feedposts] = Story.where('created_at >= ?', 1.day.ago).count
     stats[:feedcomments] = Substory.where('created_at >= ?', 1.day.ago).count
     stats[:feedlikes] = Vote.where(target_type: 'Story').where('created_at >= ?', 1.day.ago).count
+    stats[:groupjoins] = GroupMember.accepted.where('created_at >= ?', 1.day.ago).count
     stats[:pending_count] = Version.pending.count
     stats[:sha_hash] = `git log --pretty=format:'%h' -n 1`
 

--- a/app/frontend/app/templates/group/index.hbs
+++ b/app/frontend/app/templates/group/index.hbs
@@ -25,7 +25,7 @@
             </div>
             {{textarea class="edit-bio" rows="3" placeholder="Tell us about your group." value=group.truncatedAbout}}
           {{else}}
-            <p class="about">{{group.aboutDisplay}}</p>
+            <p class="about">{{{group.aboutDisplay}}}</p>
           {{/if}}
         </div>
       </div>

--- a/app/frontend/app/templates/kotodama.hbs
+++ b/app/frontend/app/templates/kotodama.hbs
@@ -39,6 +39,7 @@
               <tr><td>Feed posts</td><td>{{feedposts}}</td></tr>
               <tr><td>Feed updates</td><td>{{feedcomments}}</td></tr>
               <tr><td>Feed likes</td><td>{{feedlikes}}</td></tr>
+              <tr><td>Group joins</td><td>{{groupjoins}}</td></tr>
             </tbody>
           </table>
         </div>

--- a/app/frontend/app/templates/story/permalink.hbs
+++ b/app/frontend/app/templates/story/permalink.hbs
@@ -26,6 +26,9 @@
             {{user.truncatedBio}}
           </p>
         </div>
+        {{#if group}}
+          {{group-box group=group}}
+        {{/if}}
       </div>
 
       {{#unless currentUser.isSignedIn}}

--- a/app/frontend/app/templates/user/index.hbs
+++ b/app/frontend/app/templates/user/index.hbs
@@ -50,7 +50,7 @@
             </div>
           {{else}}
             {{#if hasAboutSection}}
-              <p class="about"> {{user.aboutDisplay}}</p>
+              <p class="about"> {{{user.aboutDisplay}}}</p>
               <div class="user-interests">
                 <ul>
                   <li>


### PR DESCRIPTION
I did some tiny tweaks to the CSS on profile pages to make it not quite as shit on mobile, namely: scrolling the pillbar horizontally instead of wrapping it, and making it so the follow button wasn't so damn *huge* or *low*

Then I fixed the bug with `aboutDisplay` rendering the raw HTML.  I don't think this will be a security issue despite the fact that it theoretically exposes the raw about text without escaping, since users can no longer set the raw about text.  Assuming nobody previously crammed a `<script>` in there, we're probably solid.

And finally I added the group box to permalink pages in a group.

And then, post-finally, I added a new statistic in kotodama of "number of approved group joins in the past 24 hours" because why not