### PR TITLE
Payment refactoring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,7 @@ group :test do
   gem 'minitest-rails'
   gem 'json_expressions'
   gem 'factory_girl_rails'
+  gem 'faker'
 end
 
 gem 'codeclimate-test-reporter', group: :test, require: nil

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,8 @@ GEM
     factory_girl_rails (4.5.0)
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
+    faker (1.4.3)
+      i18n (~> 0.5)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
     fast_blank (0.0.2)
@@ -518,6 +520,7 @@ DEPENDENCIES
   dropbox-api
   ember-cli-rails (= 0.0.18)
   factory_girl_rails
+  faker
   fast_blank
   fastclick-rails (~> 1.0)
   flamegraph

--- a/app/controllers/pro_memberships_controller.rb
+++ b/app/controllers/pro_memberships_controller.rb
@@ -22,7 +22,7 @@ class ProMembershipsController < ApplicationController
     end
 
     begin
-      update_billing current_user, token
+      update_billing token
 
       if params[:gift]
         gift_to = nil
@@ -57,10 +57,10 @@ class ProMembershipsController < ApplicationController
   end
 
   private
-  def update_billing(user, token)
-    customer = payment_method.exchange_token(token)
-    user.update_attributes! billing_method: :stripe,
-                            billing_id: customer.id
+  def update_billing(token)
+    customer = payment_method.exchange_token(current_user, token)
+    current_user.update_attributes! billing_method: :stripe,
+                                    billing_id: customer.id
   end
 
   def manager

--- a/app/controllers/pro_memberships_controller.rb
+++ b/app/controllers/pro_memberships_controller.rb
@@ -22,6 +22,8 @@ class ProMembershipsController < ApplicationController
     end
 
     begin
+      update_billing current_user, token
+
       if params[:gift]
         gift_to = nil
         begin
@@ -29,14 +31,14 @@ class ProMembershipsController < ApplicationController
         rescue
           return render(text: "Couldn't find user: #{params[:gift_to]}", status: 400)
         end
-        manager.gift! plan, token, gift_to, params[:gift_message]
+        manager.gift! plan, gift_to, params[:gift_message]
         mixpanel.track "PRO gifted", {
           gifted_to: gift_to.name,
           gifted_by: current_user.name,
           plan: plan.name
         }
       else
-        manager.subscribe! plan, token
+        manager.subscribe! plan
         mixpanel.track "PRO subscription", {
           username: current_user.name,
           plan: plan.name
@@ -55,9 +57,17 @@ class ProMembershipsController < ApplicationController
   end
 
   private
-
-  def manager
-    ProMembershipManager.new(current_user)
+  def update_billing(user, token)
+    customer = payment_method.exchange_token(token)
+    user.update_attributes! billing_method: :stripe,
+                            billing_id: customer.id
   end
 
+  def manager
+    @manager ||= ProMembershipManager.new(current_user)
+  end
+
+  def payment_method
+    @method ||= PaymentMethod.lookup('stripe')
+  end
 end

--- a/app/models/payment_method.rb
+++ b/app/models/payment_method.rb
@@ -1,0 +1,5 @@
+class PaymentMethod
+  def self.lookup(method)
+    ('PaymentMethod::' + method.classify + 'Provider').constantize
+  end
+end

--- a/app/models/payment_method.rb
+++ b/app/models/payment_method.rb
@@ -1,5 +1,5 @@
 class PaymentMethod
   def self.lookup(method)
-    ('PaymentMethod::' + method.classify + 'Provider').constantize
+    "PaymentMethod::#{method.classify}Provider".constantize
   end
 end

--- a/app/models/payment_method/stripe_provider.rb
+++ b/app/models/payment_method/stripe_provider.rb
@@ -1,0 +1,28 @@
+class PaymentMethod
+  class StripeProvider
+    def self.exchange_token(user, token)
+      # TODO: update existing customer with new card
+      ::Stripe::Customer.create(email: user.email, card: token)
+    end
+
+    def self.customer(user, token=nil)
+      ::Stripe::Customer.retrieve(user.billing_id)
+    end
+
+    # Of note: amount should be a BigDecimal of 0.00 format
+    def self.charge!(customer, amount, description='Hummingbird PRO')
+      if customer.is_a? User
+        customer_id = customer.billing_id
+      else
+        customer_id = customer.id
+      end
+      ::Stripe::Charge.create(
+        customer: customer_id,
+        # Stripe wants this in integer form
+        amount: (amount * 100).to_i,
+        description: description,
+        currency: 'usd'
+      )
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,10 +59,10 @@
 #  approved_edit_count         :integer          default(0)
 #  rejected_edit_count         :integer          default(0)
 #  pro_expires_at              :datetime
-#  stripe_token                :string(255)
 #  pro_membership_plan_id      :integer
-#  stripe_customer_id          :string(255)
+#  billing_id                  :string(255)
 #  about_formatted             :text
+#  billing_method              :integer
 #
 
 class User < ActiveRecord::Base
@@ -174,6 +174,8 @@ class User < ActiveRecord::Base
   validates_attachment :cover_image, content_type: {
     content_type: ["image/jpg", "image/jpeg", "image/png", "image/gif"]
   }
+
+  enum billing_method: [:stripe]
 
   has_many :watchlists
   has_many :library_entries, dependent: :destroy

--- a/db/migrate/20150312013116_shuffle_billing_info.rb
+++ b/db/migrate/20150312013116_shuffle_billing_info.rb
@@ -1,0 +1,9 @@
+class ShuffleBillingInfo < ActiveRecord::Migration
+  def change
+    rename_column :users, :stripe_customer_id, :billing_id
+    remove_column :users, :stripe_token
+    add_column :users, :billing_method, :int
+
+    User.update_all billing_method: 0
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1581,10 +1581,10 @@ CREATE TABLE users (
     approved_edit_count integer DEFAULT 0,
     rejected_edit_count integer DEFAULT 0,
     pro_expires_at timestamp without time zone,
-    stripe_token character varying(255),
     pro_membership_plan_id integer,
-    stripe_customer_id character varying(255),
-    about_formatted text
+    billing_id character varying(255),
+    about_formatted text,
+    billing_method integer
 );
 
 
@@ -3723,3 +3723,6 @@ INSERT INTO schema_migrations (version) VALUES ('20150206031907');
 INSERT INTO schema_migrations (version) VALUES ('20150220014905');
 
 INSERT INTO schema_migrations (version) VALUES ('20150305204429');
+
+INSERT INTO schema_migrations (version) VALUES ('20150312013116');
+

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -1,0 +1,15 @@
+FactoryGirl.define do
+  factory :user do
+    name { Faker::Internet.user_name }
+    email { Faker::Internet.email }
+    password { Faker::Internet.password }
+    avatar { Faker::Avatar.image }
+
+    trait :with_stripe do
+      billing_id { Stripe::Customer.create({
+        email: email,
+        card: StripeMock.create_test_helper.generate_card_token
+      }).id }
+    end
+  end
+end

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :user do
-    name { Faker::Internet.user_name }
+    name { Faker::Internet.user_name(nil, ['_']) }
     email { Faker::Internet.email }
     password { Faker::Internet.password }
     avatar { Faker::Avatar.image }
@@ -10,6 +10,7 @@ FactoryGirl.define do
         email: email,
         card: StripeMock.create_test_helper.generate_card_token
       }).id }
+      billing_method :stripe
     end
   end
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -59,10 +59,10 @@
 #  approved_edit_count         :integer          default(0)
 #  rejected_edit_count         :integer          default(0)
 #  pro_expires_at              :datetime
-#  stripe_token                :string(255)
 #  pro_membership_plan_id      :integer
-#  stripe_customer_id          :string(255)
+#  billing_id                  :string(255)
 #  about_formatted             :text
+#  billing_method              :integer
 #
 
 vikhyat:

--- a/test/models/payment_method/stripe_provider_test.rb
+++ b/test/models/payment_method/stripe_provider_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+class PaymentMethod::StripeProviderTest < ActiveSupport::TestCase
+  before { StripeMock.start }
+  after { StripeMock.stop }
+
+  let(:stripe_helper) { StripeMock.create_test_helper }
+
+  test "#customer" do
+    user = build(:user, :with_stripe)
+    customer = PaymentMethod::StripeProvider.customer(user)
+
+    customer.must_be_kind_of Stripe::Customer
+    customer.email.must_equal user.email
+  end
+
+  test "#exchange_token" do
+    user = build(:user)
+    token = stripe_helper.generate_card_token
+
+    customer = PaymentMethod::StripeProvider.exchange_token(user, token)
+    customer.email.must_equal user.email
+  end
+
+  test "#charge!" do
+    user = build(:user, :with_stripe)
+
+    Stripe::Charge.expects(:create).with({
+      customer: user.billing_id,
+      amount: 500,
+      description: 'hi',
+      currency: 'usd'
+    })
+
+    PaymentMethod::StripeProvider.charge! user, BigDecimal.new('5.00'), 'hi'
+  end
+end

--- a/test/models/payment_method_test.rb
+++ b/test/models/payment_method_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class PaymentMethodTest < ActiveSupport::TestCase
+  test "#lookup" do
+    PaymentMethod.lookup('stripe').must_equal PaymentMethod::StripeProvider
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -59,10 +59,10 @@
 #  approved_edit_count         :integer          default(0)
 #  rejected_edit_count         :integer          default(0)
 #  pro_expires_at              :datetime
-#  stripe_token                :string(255)
 #  pro_membership_plan_id      :integer
-#  stripe_customer_id          :string(255)
+#  billing_id                  :string(255)
 #  about_formatted             :text
+#  billing_method              :integer
 #
 
 require 'test_helper'

--- a/test/services/pro_membership_manager_test.rb
+++ b/test/services/pro_membership_manager_test.rb
@@ -53,6 +53,9 @@ class ProMembershipManagerTest < ActiveSupport::TestCase
     manager = ProMembershipManager.new(user)
     plan = ProMembershipPlan.find(5)
 
+    manager.expects(:give_pro!).with(user, plan.duration.months)
+    PaymentMethod::StripeProvider.expects(:charge!).with(user, plan.amount)
+
     manager.subscribe! plan
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,10 +15,13 @@ require 'webmock_helper'
 
 require 'mocha/mini_test'
 
+require 'stripe_mock'
+
 $redis = ConnectionPool.new { MockRedis.new }
 
 class ActiveSupport::TestCase
   fixtures :all
+  include FactoryGirl::Syntax::Methods
 end
 
 require_dependency 'auth/current_user_provider'

--- a/test/webmock_helper.rb
+++ b/test/webmock_helper.rb
@@ -1,4 +1,4 @@
-WebMock.disable_net_connect!(:allow => "codeclimate.com")
+WebMock.disable_net_connect!(allow: ['codeclimate.com', 'robohash.org'])
 
 class ActiveSupport::TestCase
   def fake_requests(routes)


### PR DESCRIPTION
Basic premise is that billing (PaymentMethod) is extracted from the stuff which juggles PRO (ProMembershipManager).  Right now there's places where it's hardwired to Stripe, but I've extracted it so that unwiring those will be a simple task.

I also removed the elements of the ProMembershipManager which updated billing info and moved that to the controller instead.

I also dropped the token column (and all the token-passing) because in both Stripe and Braintree, the token is a nonce.  We can't reuse it and it's not needed.  We only need the customer id.