### PR TITLE
Fix cover image uploads, remove ridiculous production check

### DIFF
--- a/app/assets/stylesheets/base/hacks.css.scss
+++ b/app/assets/stylesheets/base/hacks.css.scss
@@ -210,6 +210,11 @@ a.navbar-brand {
 /* JCrop Stuff */
 .jcrop {
   text-align: center;
+
+  img {
+    max-width: none;
+  }
+
   .jcrop-holder {
     display: inline-block;
   }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -241,7 +241,7 @@ class UsersController < ApplicationController
       user.bio = changes[:bio] || ""
       user.waifu_char_id = changes[:waifu_char_id]
 
-      if Rails.env.production? and changes[:cover_image_url] =~ /^data:image/
+      if changes[:cover_image_url] =~ /^data:image/
         user.cover_image = changes[:cover_image_url]
       end
 


### PR DESCRIPTION
:arrow_up: :arrow_down:

Recent Onebox CSS update applied `max-width: 100%` to all `<img>` elements, which fucked with the way we do cropping.