### PR TITLE
Fix removing single story liker

### DIFF
--- a/app/serializers/story_serializer.rb
+++ b/app/serializers/story_serializer.rb
@@ -60,7 +60,7 @@ class StorySerializer < ActiveModel::Serializer
                      .sort_by {|x| x.created_at }.reverse.take(2)
   end
 
-  def include_recent_likers?
-    !object.recent_likers.nil?
+  def recent_likers
+    object.recent_likers || []
   end
 end


### PR DESCRIPTION
We have a :beetle: at the moment, where if you are the only _liker_ on a story, and you unlike that story, your avatar doesn't actually get removed.

This fixes that. :beetle: :gun: