### PR TITLE
Trending groups via SQL view

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -5,7 +5,7 @@ class GroupsController < ApplicationController
     page = (params[:page] || 1).to_i
 
     groups = if params[:trending].present?
-      Group.trending(page: page, per: limit)
+      Group.trending(current_user).page(page).per(limit).groups
     elsif params[:user_id].present?
       User.find(params[:user_id]).groups.order('id ASC').page(page).per(limit)
     else

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -128,8 +128,12 @@ class Group < ActiveRecord::Base
     group
   end
 
-  def self.trending(page: 1, per: 10)
-    TrendingGroups.list(page: page, per: per)
+  def self.trending(user=nil)
+    if user
+      TrendingGroup.not_joined_by_user(user)
+    else
+      TrendingGroup.all
+    end
   end
 
   before_save do

--- a/app/models/trending_group.rb
+++ b/app/models/trending_group.rb
@@ -9,7 +9,7 @@ class TrendingGroup < ActiveRecord::Base
   def self.not_joined_by_user(user)
     user = user.id if user.is_a?(User)
     TrendingGroup.where.not(
-      group: GroupMember.where(user_id: 2).select(:group_id)
+      group: GroupMember.where(user_id: user).select(:group_id)
     )
   end
 

--- a/app/models/trending_group.rb
+++ b/app/models/trending_group.rb
@@ -1,0 +1,19 @@
+class TrendingGroup < ActiveRecord::Base
+  self.table_name = 'trending_groups'
+  after_initialize :readonly!
+
+  belongs_to :group
+
+  default_scope ->{ order('score DESC').includes(:group) }
+
+  def self.not_joined_by_user(user)
+    user = user.id if user.is_a?(User)
+    TrendingGroup.where.not(
+      group: GroupMember.where(user_id: 2).select(:group_id)
+    )
+  end
+
+  def self.groups
+    select(:group_id).map { |x| x.group }
+  end
+end

--- a/app/workers/trending_groups_refresh_worker.rb
+++ b/app/workers/trending_groups_refresh_worker.rb
@@ -1,0 +1,10 @@
+class TrendingGroupsRefreshWorker
+  include Sidekiq::Worker
+  include Sidetiq::Schedulable
+
+  recurrence { minutely(5) }  
+
+  def perform
+    TrendingGroup.connection.execute('REFRESH MATERIALIZED VIEW trending_groups')
+  end
+end

--- a/config/initializers/postgresql_view_support.rb
+++ b/config/initializers/postgresql_view_support.rb
@@ -1,0 +1,25 @@
+ActiveSupport.on_load(:active_record) do
+  ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.class_eval do
+    def table_exists?(name)
+      return true if super
+      name = name.to_s
+      schema, table = name.split('.', 2)
+
+      unless table # A table was provided without a schema
+        table = schema
+        schema = nil
+      end
+
+      if name =~ /^"/ # handle quoted table names
+        table = name
+        schema = nil
+      end
+
+      query(<<-SQL).first[0].to_i > 0
+        SELECT COUNT(*) FROM pg_views
+        WHERE viewname = '#{table.gsub(/(^"|"$)/, '')}'
+        #{schema ? "AND schemaname = '#{schema}'" : ''}
+      SQL
+    end
+  end
+end

--- a/db/migrate/20150317215112_create_trending_groups_views.rb
+++ b/db/migrate/20150317215112_create_trending_groups_views.rb
@@ -1,0 +1,82 @@
+class CreateTrendingGroupsViews < ActiveRecord::Migration
+  def up
+    # This hefty SQL view takes the group_members and groups by (group.id,
+    # created_at), infilling with zeroes for dead times since the founding of
+    # the group
+    execute(<<-SQL)
+CREATE OR REPLACE VIEW group_members_histogram AS
+SELECT coalesce(counts.cnt, 0) AS cnt, fills.*
+FROM ( -- Buckets infilled with zeroes
+  SELECT *
+  FROM ( -- All possible (group_id, created_at) tuples
+    SELECT groups.id AS group_id, groups.created_at AS founded, generate_series AS created_at
+    FROM groups
+    -- floor(now) - 30.days ... ceil(now) with 1-hour intervals
+    CROSS JOIN generate_series(date_trunc('hour', timezone('utc', now())) - interval '30 days', timezone('utc', now()) + interval '1 hour', '1 hour')
+  ) AS buckets
+  WHERE buckets.created_at >= date_trunc('hour', buckets.founded)
+) AS fills
+LEFT OUTER JOIN (
+  SELECT count(*) AS cnt, group_id, date_trunc('hour', created_at) AS created_at
+  FROM group_members
+  WHERE created_at > (now() - interval '30 days')
+  GROUP BY group_id, date_trunc('hour', created_at)
+) AS counts
+ON counts.created_at = fills.created_at
+AND counts.group_id = fills.group_id
+    SQL
+
+    # This even heftier SQL view takes the bucketed group_members_histogram and
+    # generates average and sum for two periods (7-day and 6-hour) and the
+    # deviation.  From this it calculates the z-score.
+    # This view is _materialized_ and refreshed every 5 minutes
+    execute(<<-SQL)
+CREATE MATERIALIZED VIEW trending_groups AS
+SELECT
+  groups.id AS group_id,
+  short_avg AS short_avg,
+  short_sum AS short_sum,
+  long_avg AS long_avg,
+  long_sum AS long_sum,
+  deviation AS deviation,
+  trending.score AS score
+FROM groups
+JOIN (
+  SELECT
+    long_term.group_id AS group_id,
+    short_term.avg AS short_avg,
+    short_term.sum AS short_sum,
+    long_term.avg AS long_avg,
+    long_term.sum AS long_sum,
+    long_term.dev AS deviation,
+    -- The weird addition here is a silly hack to prevent division by zero
+    (short_term.avg - long_term.avg) / (long_term.dev + 0.0000000001) AS score
+  FROM ( -- Get the sum, deviation, and average for the hourly data of the past 7 days
+    SELECT group_id, count(cnt) AS cnt, sum(cnt) AS sum, stddev_pop(cnt) AS dev, avg(cnt) AS avg
+    FROM group_members_histogram
+    WHERE created_at >= (date_trunc('hour', now()) - interval '7 days')
+    -- This is to prevent groups from showing up until there's reasonable data
+    AND founded < (date_trunc('hour', now()) - interval '6 hours')
+    GROUP BY group_id
+  ) AS long_term
+  JOIN ( -- Get the sum and average for the hourly data of the past 6 hours
+    SELECT group_id, count(cnt) AS cnt, sum(cnt) AS sum, avg(cnt) AS avg
+    FROM group_members_histogram
+    WHERE created_at >= (date_trunc('hour', now()) - interval '6 hours')
+    -- This is to prevent groups from showing up until there's reasonable data
+    AND founded < (date_trunc('hour', now()) - interval '6 hours')
+    GROUP BY group_id
+  ) AS short_term
+  ON short_term.group_id = long_term.group_id
+) AS trending
+ON trending.group_id = groups.id
+WHERE trending.score IS NOT NULL
+AND groups.confirmed_members_count > 5
+ORDER BY trending.score DESC
+    SQL
+  end
+  def down
+    execute 'DROP MATERIALIZED VIEW trending_groups'
+    execute 'DROP VIEW group_members_histogram'
+  end
+end

--- a/db/migrate/20150317215112_create_trending_groups_views.rb
+++ b/db/migrate/20150317215112_create_trending_groups_views.rb
@@ -19,7 +19,7 @@ FROM ( -- Buckets infilled with zeroes
 LEFT OUTER JOIN (
   SELECT count(*) AS cnt, group_id, date_trunc('hour', created_at) AS created_at
   FROM group_members
-  WHERE created_at > (now() - interval '30 days')
+  WHERE created_at > (timezone('utc', now()) - interval '30 days')
   GROUP BY group_id, date_trunc('hour', created_at)
 ) AS counts
 ON counts.created_at = fills.created_at
@@ -54,17 +54,17 @@ JOIN (
   FROM ( -- Get the sum, deviation, and average for the hourly data of the past 7 days
     SELECT group_id, count(cnt) AS cnt, sum(cnt) AS sum, stddev_pop(cnt) AS dev, avg(cnt) AS avg
     FROM group_members_histogram
-    WHERE created_at >= (date_trunc('hour', now()) - interval '7 days')
+    WHERE created_at >= (date_trunc('hour', timezone('utc', now())) - interval '7 days')
     -- This is to prevent groups from showing up until there's reasonable data
-    AND founded < (date_trunc('hour', now()) - interval '6 hours')
+    AND founded < (date_trunc('hour', timezone('utc', now())) - interval '6 hours')
     GROUP BY group_id
   ) AS long_term
   JOIN ( -- Get the sum and average for the hourly data of the past 6 hours
     SELECT group_id, count(cnt) AS cnt, sum(cnt) AS sum, avg(cnt) AS avg
     FROM group_members_histogram
-    WHERE created_at >= (date_trunc('hour', now()) - interval '6 hours')
+    WHERE created_at >= (date_trunc('hour', timezone('utc', now())) - interval '6 hours')
     -- This is to prevent groups from showing up until there's reasonable data
-    AND founded < (date_trunc('hour', now()) - interval '6 hours')
+    AND founded < (date_trunc('hour', timezone('utc', now())) - interval '6 hours')
     GROUP BY group_id
   ) AS short_term
   ON short_term.group_id = long_term.group_id

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -877,7 +877,7 @@ CREATE VIEW group_members_histogram AS
             group_members.group_id,
             date_trunc('hour'::text, group_members.created_at) AS created_at
            FROM group_members
-          WHERE (group_members.created_at > (now() - '30 days'::interval))
+          WHERE (group_members.created_at > (timezone('utc'::text, now()) - '30 days'::interval))
           GROUP BY group_members.group_id, date_trunc('hour'::text, group_members.created_at)) counts ON (((counts.created_at = fills.created_at) AND (counts.group_id = fills.group_id))));
 
 
@@ -1571,14 +1571,14 @@ CREATE MATERIALIZED VIEW trending_groups AS
                     stddev_pop(group_members_histogram.cnt) AS dev,
                     avg(group_members_histogram.cnt) AS avg
                    FROM group_members_histogram
-                  WHERE ((group_members_histogram.created_at >= (date_trunc('hour'::text, now()) - '7 days'::interval)) AND (group_members_histogram.founded < (date_trunc('hour'::text, now()) - '06:00:00'::interval)))
+                  WHERE ((group_members_histogram.created_at >= (date_trunc('hour'::text, timezone('utc'::text, now())) - '7 days'::interval)) AND (group_members_histogram.founded < (date_trunc('hour'::text, timezone('utc'::text, now())) - '06:00:00'::interval)))
                   GROUP BY group_members_histogram.group_id) long_term
              JOIN ( SELECT group_members_histogram.group_id,
                     count(group_members_histogram.cnt) AS cnt,
                     sum(group_members_histogram.cnt) AS sum,
                     avg(group_members_histogram.cnt) AS avg
                    FROM group_members_histogram
-                  WHERE ((group_members_histogram.created_at >= (date_trunc('hour'::text, now()) - '06:00:00'::interval)) AND (group_members_histogram.founded < (date_trunc('hour'::text, now()) - '06:00:00'::interval)))
+                  WHERE ((group_members_histogram.created_at >= (date_trunc('hour'::text, timezone('utc'::text, now())) - '06:00:00'::interval)) AND (group_members_histogram.founded < (date_trunc('hour'::text, timezone('utc'::text, now())) - '06:00:00'::interval)))
                   GROUP BY group_members_histogram.group_id) short_term ON ((short_term.group_id = long_term.group_id)))) trending ON ((trending.group_id = groups.id)))
   WHERE ((trending.score IS NOT NULL) AND (groups.confirmed_members_count > 5))
   ORDER BY trending.score DESC


### PR DESCRIPTION
>[Active Record] was built on the notion that SQL is neither dirty nor bad, just verbose in the trivial cases. The focus is on removing the need to deal with the verbosity in those trivial cases (writing a 10-attribute insert by hand will leave any programmer tired) but keeping the expressiveness around for the hard queries—the type SQL was created to deal with elegantly.

— DHH, [Agile Web Development with Rails](http://event2011.googlecode.com/files/Agile_Web.pdf)

This basically calculates the z-score via two SQL views, one of which is a "materialized view".  One view is used to generate a "histogram" of GroupMembers by created_at.  The other (materialized) view then uses this data to calculate the z-score.

The materialized view is updated every 5 minutes by a Sidetiq worker.

On display, we remove groups the current user is in already.