### PR TITLE
Add MAL id to APIv1 anime responses

### DIFF
--- a/app/api/api_v1.rb
+++ b/app/api/api_v1.rb
@@ -91,6 +91,7 @@ class API_v1 < Grape::API
       if anime
         json = {
           id: anime.id,
+          mal_id: anime.mal_id,
           slug: anime.slug,
           status: anime.status,
           url: "https://hummingbird.me/anime/#{anime.slug}",


### PR DESCRIPTION
This change adds the MAL id to the hash returned by `present_anime` in `api_v1.rb`.

There are many services today that integrate with MAL. In many cases this is likely done by keeping some kind of mapping between the MAL id and the local id of anime entries, much like Hummingbird does. Including the MAL id when using Hummingbird's API would make it easier to extend these services to integrate with Hummingbird.