### PR TITLE
Fix recursion in authentication code

### DIFF
--- a/lib/auth/helpers.rb
+++ b/lib/auth/helpers.rb
@@ -30,7 +30,7 @@ module Auth
       current_user_provider = env[CURRENT_USER_PROVIDER_KEY]
 
       if user_signed_in?
-        sign_in(current_user) if current_user_provider.token.expires_in < 1.month
+        current_user_provider.log_on_user(current_user, cookies) if current_user_provider.token.expires_in < 1.month
         current_user.update_ip! request.remote_ip
       end
     end


### PR DESCRIPTION
Solves the errors users have started seeing, now that the 2 month mark of when we forced all users to get new tokens (which was how we "solved" the previous 2 month mark) has come around.

The problem was that `sign_in` calls `check_user_authentication`, which causes recursion in the case of a token refresh.  It doesn't recurse on the other codepath which uses `sign_in` (updating from an old `auth_token` cookie) because that path deletes the cookie which triggers that path, thus breaking the recursion after one loop.  Still kind of shitty but at least that route doesn't break anything.