### PR TITLE
Fix Erroneous Ellipsis Overflow

### DIFF
--- a/app/assets/stylesheets/partials/status-panel.css.scss
+++ b/app/assets/stylesheets/partials/status-panel.css.scss
@@ -172,7 +172,6 @@
     padding: 0;
     margin-bottom: 0;
     overflow: hidden;
-    text-overflow: ellipsis;
     max-height: 500px;
 
     img {
@@ -180,8 +179,10 @@
     }
 
     a {
+      display: block;
       white-space: nowrap;
       overflow: hidden;
+      text-overflow: ellipsis;
     }
 
     .onebox a {


### PR DESCRIPTION
I believe this was designed for the "show more" cut-off point - but this doesn't work there anyway... :confounded: 

This solves a somewhat rare issue in Blink's/Chrome(?) rendering which will add an ellipsis for any lines that "overflow" the container, instead of dropping the word to the next line.

Example:
![](http://a.pomf.se/ylyuyl.png) 
![](http://a.pomf.se/lkvmzw.png) On the last full line the word "subs" is right up against the container's width and Chrome changes it to "su...".

Without `text-overflow: ellipsis`:

![](http://a.pomf.se/lxjzbl.png)

The text is **not** overflowing the container.

![](http://a.pomf.se/hnrxgd.png)