### PR TITLE
Hotfix for Genre Padding

### DIFF
--- a/app/assets/stylesheets/base/base.css.scss
+++ b/app/assets/stylesheets/base/base.css.scss
@@ -52,9 +52,9 @@ a {
   li {
     display: inline-block;
     float: left;
-    padding-right: 10px;
+    padding-right: 0;
     &:last-child {
-      padding-right: 0;
+       padding-right: 0;
     }
   }
 }

--- a/app/assets/stylesheets/base/base.css.scss
+++ b/app/assets/stylesheets/base/base.css.scss
@@ -53,9 +53,6 @@ a {
     display: inline-block;
     float: left;
     padding-right: 0;
-    &:last-child {
-       padding-right: 0;
-    }
   }
 }
 

--- a/app/assets/stylesheets/partials/onboarding.css.scss
+++ b/app/assets/stylesheets/partials/onboarding.css.scss
@@ -310,6 +310,10 @@
 
 .library-tabs {
   @extend .clearfix;
+  
+  li {
+    padding-right: 10px;
+  }
   .anime-tab, .manga-tab {
     display: inline-block;
     padding: 6px 18px;

--- a/app/assets/stylesheets/partials/status-panel.css.scss
+++ b/app/assets/stylesheets/partials/status-panel.css.scss
@@ -84,12 +84,9 @@
     
     font-size: 14px;
     
-    li {
-      padding-right: 0;
-      /* because metamorphs */
-      &:last-of-type:after {
-        content: "";
-      }
+    /* because metamorphs */
+    li:last-of-type:after {
+      content: "";
     }
   }
 
@@ -151,7 +148,6 @@
 
   .inline-list {
     li {
-      padding-right: 0;
       &:after {
         content: "\a0\00b7\a0";
         padding: 0 3px;


### PR DESCRIPTION
Changed Base `inline-css` to `padding-right: 0` as the only element importing `inline-css` and **using** the default 10px was onboarding. Everything else (or attempted to) overwrote it.

Fixes PR 422.