### PR TITLE
show feedback on simple onboarding

### DIFF
--- a/app/assets/stylesheets/partials/onboarding.css.scss
+++ b/app/assets/stylesheets/partials/onboarding.css.scss
@@ -125,7 +125,7 @@
 
 // Step 1 - Start
 .start-wrapper {
-  padding-left: 35px; 
+  padding-left: 35px;
   padding-right: 0;
   margin-top: 20px;
   @media (max-width: 800px) {
@@ -159,7 +159,7 @@
   }
 }
 
-// Step 2 - Rating 
+// Step 2 - Rating
 
 .rating-wrapper {
   @extend .clearfix;
@@ -300,6 +300,15 @@
   .awesome-rating-widget {
     font-size: 24px;
     color: #A3A4A9;
+    i.simple {
+      padding: 0 5px;
+      &.active {
+        color: $darkOrange;
+      }
+      &:hover {
+        color: black;
+      }
+    }
   }
 }
 
@@ -323,7 +332,7 @@
       color: #333;
       text-decoration: none;
     }
-    
+
   }
 }
 .search-wrapper {

--- a/frontend/app/models/manga.js
+++ b/frontend/app/models/manga.js
@@ -14,6 +14,7 @@ export default Media.extend({
   chapterCount: DS.attr("number"),
   genres: DS.attr("array"),
   mangaLibraryEntry: DS.belongsTo("manga-library-entry"),
+  libraryEntry: Ember.computed.alias('mangaLibraryEntry'),
   displayTitle: Ember.computed.alias('romajiTitle'),
   lowercaseDisplayTitle: (function() {
     return this.get("displayTitle").toLowerCase();


### PR DESCRIPTION
When using the `simple` rating system, it doesn't show any feedback about which rating you have chosen on the onboarding section.

Also, the code for onboarding was referencing `media.libraryEntry` which failed on manga and made it always try to create a new library entry which would fail on the backend.