### PR TITLE
Fix #512: posterImageThumb returning non-existent Images

### DIFF
--- a/app/serializers/anime_serializer.rb
+++ b/app/serializers/anime_serializer.rb
@@ -2,9 +2,9 @@ class AnimeSerializer < ActiveModel::Serializer
   embed :ids
 
   attributes :id, :canonical_title, :english_title, :romaji_title, :synopsis,
-    :poster_image, :show_type, :age_rating, :age_rating_guide, :episode_count,
-    :episode_length, :started_airing, :started_airing_date_known,
-    :finished_airing, :genres, :updated_at
+    :poster_image, :poster_image_thumb, :show_type, :age_rating,
+    :age_rating_guide, :episode_count, :episode_length, :started_airing,
+    :started_airing_date_known, :finished_airing, :genres, :updated_at
 
   def id
     object.slug
@@ -23,6 +23,14 @@ class AnimeSerializer < ActiveModel::Serializer
       "/assets/missing-anime-cover.jpg"
     else
       object.poster_image.url(:large)
+    end
+  end
+
+  def poster_image_thumb
+    if !object.sfw? && (scope.nil? || scope.try(:sfw_filter))
+      "/assets/missing-anime-cover.jpg"
+    else
+      object.poster_image.url(:medium)
     end
   end
 

--- a/app/serializers/manga_serializer.rb
+++ b/app/serializers/manga_serializer.rb
@@ -5,6 +5,7 @@ class MangaSerializer < ActiveModel::Serializer
              :romaji_title,
              :english_title,
              :poster_image,
+             :poster_image_thumb,
              :synopsis,
              :chapter_count,
              :volume_count,
@@ -23,6 +24,10 @@ class MangaSerializer < ActiveModel::Serializer
   end
 
   def poster_image
+    object.poster_image.url(:large)
+  end
+
+  def poster_image_thumb
     object.poster_image.url(:large)
   end
 

--- a/frontend/app/models/anime.js
+++ b/frontend/app/models/anime.js
@@ -10,6 +10,7 @@ export default Media.extend(ModelCurrentUser, {
   romajiTitle: DS.attr('string'),
   synopsis: DS.attr('string'),
   posterImage: DS.attr('string'),
+  posterImageThumb: DS.attr('string'),
   showType: DS.attr('string'),
   ageRating: DS.attr('string'),
   ageRatingGuide: DS.attr('string'),
@@ -24,10 +25,6 @@ export default Media.extend(ModelCurrentUser, {
   nsfw: function() {
     return this.get('ageRating') === "R18+" || this.get('ageRating') === "R17+";
   }.property('ageRating'),
-
-  posterImageThumb: function(){
-    return this.get('posterImage').replace("/large/", "/medium/");
-  }.property('posterImage'),
 
   displayTitle: function() {
     var currentUser, pref, title;

--- a/frontend/app/models/manga.js
+++ b/frontend/app/models/manga.js
@@ -8,6 +8,7 @@ export default Media.extend({
   romajiTitle: DS.attr("string"),
   englishTitle: DS.attr("string"),
   posterImage: DS.attr("string"),
+  posterImageThumb: DS.attr("string"),
   synopsis: DS.attr("string"),
   mangaType: DS.attr("string"),
   volumeCount: DS.attr("number"),


### PR DESCRIPTION
Hello guys! 

This is my first Pull Request ever, so let me know if I missed something important :)

This PR has 2 commits intended to fix an error reported on issue #512, where images wasn't showing properly when you click to edit the favorite list. This code solves the problem, but I think I can work a little further, like:

- The method `poster_image_thumb` name holds little meaning now that it have two uses. Maybe refactor this to `image_path` or something like that?
- Move the path generation from Ember to Rails and return `medium_image` instead of `original_image`?
- Maybe move this attachments and paths into a concern, as this is used on two models, so we can DRY it a little?
- There wasn't any tests regarding image paths, but I don't know if it's necessary and/or how to start this. 

What you guys think? :)