### PR TITLE
Rack::Attack for story creation

### DIFF
--- a/config/initializers/rack-attack.rb
+++ b/config/initializers/rack-attack.rb
@@ -20,6 +20,12 @@ class Rack::Attack
   #  end
   #end
 
+  throttle 'stories/cookie', limit: 10, period: 10.minutes do |req|
+    if req.path == '/stories' && req.post?
+      req.cookies['token'].presence
+    end
+  end
+
   self.throttled_response = lambda do |env|
     [429, {}, {
       error: "Rate Limit Exceeded"


### PR DESCRIPTION
Limit users to 30 posts per 30 minutes.  I feel this is unlikely to be hit by most users, but low enough to block the worst of spammers (ie jvcs22)