### PR TITLE
Fix polymorphic association error on eager loading

### DIFF
--- a/app/api/api_v1.rb
+++ b/app/api/api_v1.rb
@@ -310,7 +310,11 @@ class API_v1 < Grape::API
       user = find_user(params[:user_id])
 
       # Find stories to display.
-      stories = user.stories.for_user(current_user).order('updated_at DESC').includes(:substories, :user, :target, target: :genres).page(params[:page]).per(20)
+      stories = user.stories.for_user(current_user).includes(:substories, :user, :target).order('updated_at DESC').page(params[:page]).per(20)
+      # fetche anime stories and preload genres association
+      anime_stories = stories.group_by(&:target_type).fetch("Anime",[])
+      ActiveRecord::Associations::Preloader.new.preload(anime_stories, target: [:genres])
+
       stories.map {|x| present_story(x, current_user, current_user.try(:title_language_preference) || "canonical") }
     end
 


### PR DESCRIPTION
This is a new approach to eager loading anime genres, since the last one I did won't be on Rails until 5.0… :laughing: 

This fix the issue #539. I think the loading are ok now:

    Started GET "/api/v1/users/DNA/feed" for 127.0.0.1 at 2015-05-11 16:54:22 -0300
      User Load (3.4ms)  SELECT  "users".* FROM "users"  WHERE (LOWER(name) = 'dna')  ORDER BY "users"."id" ASC LIMIT 1
      Story Load (1.2ms)  SELECT  "stories".* FROM "stories" LEFT OUTER JOIN watchlists ON watchlists.id = stories.watchlist_id     WHERE "stories"."user_id" = $1 AND (NOT adult) AND (watchlists.id IS NULL OR watchlists.private = 'f')  ORDER BY updated_at     DESC LIMIT 20 OFFSET 0  [["user_id", 1]]
      Substory Load (2.8ms)  SELECT "substories".* FROM "substories"  WHERE "substories"."story_id" IN (5, 4, 3, 2, 1)
      User Load (2.8ms)  SELECT "users".* FROM "users"  WHERE "users"."id" IN (1)
      CACHE (0.0ms)  SELECT "users".* FROM "users"  WHERE "users"."id" IN (1)
      Anime Load (2.8ms)  SELECT "anime".* FROM "anime"  WHERE "anime"."id" IN (27, 18, 3, 2)
      HABTM_Genres Load (1.6ms)  SELECT "anime_genres".* FROM "anime_genres"  WHERE "anime_genres"."anime_id" IN (27, 18, 3, 2)
      Genre Load (1.5ms)  SELECT "genres".* FROM "genres"  WHERE "genres"."id" IN (2, 22, 10, 14, 32, 35, 5, 26, 28, 29, 37)