### PR TITLE
Apps page updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,9 @@ group :development do
   gem 'foreman'
   gem 'letter_opener'
   gem 'guard-livereload', require: false
+  gem 'guard-minitest', require: false
   gem 'rack-livereload'
+  gem 'rb-readline', require: false
   gem 'rb-fsevent', require: false
   gem 'qunit-rails'
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,10 +187,14 @@ GEM
       lumberjack (~> 1.0)
       pry (>= 0.9.12)
       thor (>= 0.18.1)
+    guard-compat (1.2.1)
     guard-livereload (2.3.1)
       em-websocket (~> 0.5)
       guard (~> 2.0)
       multi_json (~> 1.8)
+    guard-minitest (2.4.4)
+      guard-compat (~> 1.2)
+      minitest (>= 3.0)
     haml (4.0.5)
       tilt
     haml-rails (0.5.3)
@@ -377,6 +381,7 @@ GEM
     rb-fsevent (0.9.4)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
+    rb-readline (0.5.2)
     rdiscount (2.1.7.1)
     react-rails (0.10.0.0)
       execjs
@@ -531,6 +536,7 @@ DEPENDENCIES
   friendly_id (~> 5.0)
   grape
   guard-livereload
+  guard-minitest
   haml (~> 4.0)
   haml-rails
   hiredis
@@ -569,6 +575,7 @@ DEPENDENCIES
   rails (= 4.1.9)
   rails_admin
   rb-fsevent
+  rb-readline
   rdiscount
   react-rails (~> 0.10.0.0)
   redis

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -459,7 +459,7 @@ GEM
     sitemap_generator (5.0.5)
       builder
     slop (3.6.0)
-    spring (1.3.3)
+    spring (1.3.6)
     sprockets (2.11.0)
       hike (~> 1.2)
       multi_json (~> 1.0)

--- a/Guardfile
+++ b/Guardfile
@@ -1,3 +1,5 @@
+ignore([%r{log/.*}, %r{tmp/.*}, %r{frontend/tmp/.*}])
+
 guard 'livereload' do
   #watch(%r{app/assets/.+\.(hbs|emblem)$})
   #watch(%r{app/views/.+\.(erb|haml|slim)$})
@@ -9,4 +11,17 @@ guard 'livereload' do
   watch(%r{(app|vendor)(/assets/\w+/(.+\.(css|js|html))).*}) { |m| "/assets/#{m[3]}" }
   # Ember
   watch(%r{frontend/app/\w+/.+\.(js|hbs)})
+end
+
+guard :minitest, spring: true, all_on_start: false do
+  watch(%r{test/.*_test\.rb})
+  watch(%r{test/test_helper\.rb}) { 'test' }
+
+  # When files change, run the related test
+  watch(%r{lib/(.*/)?([^/]+)\.rb}) { |m| "test/lib/#{m[1]}#{m[2]}_test.rb" }
+  watch(%r{app/controllers/(.*/)?([^/]+)\.rb}) { |m| a = "test/controllers/#{m[1]}#{m[2]}_test.rb" }
+  # Ideally these would trigger both model and controller tests but it looks
+  # like we can't trigger multiple things with Guard-MiniTest
+  watch(%r{app/models/(.*/)?([^/]+)\.rb}) { |m| "test/models/#{m[1]}#{m[2]}_test.rb" }
+  watch(%r{app/(?:factories|fixtures)/(.*/)?([^/]+)\.rb}) { |m| "test/controllers/#{m[1]}#{m[2]}_controller_test.rb" }
 end

--- a/app/assets/stylesheets/base/hacks.css.scss
+++ b/app/assets/stylesheets/base/hacks.css.scss
@@ -16,6 +16,14 @@ input:focus, textarea:focus {
   border: 1px solid $darkOrange;
 }
 
+/* Asterisks for required field labels */
+.required-label::after {
+  content: '*';
+  color: $darkOrange;
+  // Move one character to the right
+  margin-right: -1ch;
+}
+
 
 /* Simple padding container for forms */
 .form-block-item {

--- a/app/assets/stylesheets/partials/apps-page.css.scss
+++ b/app/assets/stylesheets/partials/apps-page.css.scss
@@ -16,7 +16,8 @@
     color: #ebab67;
   }
   &.condensed {
-    height: 200px;
+    min-height: 0;
+    height: 140px;
     padding-top: 20px;
   }
   .btn {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -73,15 +73,30 @@ class ApplicationController < ActionController::Base
 
   # Creates a controller action which does a "default" Ember rendering
   def self.ember_action(action_name, accept_json = false, &block)
-    define_method(action_name.to_sym) do
-      respond_with_ember(instance_eval(&block), accept_json)
+    if block_given?
+      define_method(action_name.to_sym) do
+        respond_with_ember(instance_eval(&block), accept_json)
+      end
+    else
+      define_method(action_name.to_sym) do
+        render_ember
+      end
+    end
+  end
+
+  # Save and render
+  def save_and_render(model)
+    if model.save
+      render json: model
+    else
+      error! model.errors.to_h, 422
     end
   end
 
   # Render a JSON error with the given error message and status code.
   def error!(message, status)
     # If the message is a Hash of errors, we put it in standard ED form
-    if status.is_a?(Hash)
+    if message.is_a?(Hash)
       render json: {errors: message}, status: status
     else
       render json: {error: message}, status: status

--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -1,9 +1,10 @@
 class AppsController < ApplicationController
-  def mine
-    apps = App.where(creator: current_user)
-    preload_to_ember! apps
-    render_ember
-  end
+  before_action :authenticate_user!, only: [:new, :create, :update, :mine]
+
+  ember_action(:mine) { App.where(creator: current_user) }
+  ember_action(:show, true) { App.find(params[:id]) }
+  ember_action(:new)
+  ember_action(:edit)
 
   def index
     if params[:creator]
@@ -12,12 +13,7 @@ class AppsController < ApplicationController
       apps = {}
     end
 
-    respond_to do |format|
-      format.json { render json: apps }
-      format.html do
-        render_ember
-      end
-    end
+    respond_with_ember apps
   end
 
   def show
@@ -25,8 +21,7 @@ class AppsController < ApplicationController
     app
   end
 
-  def new
-    render_ember
+    save_and_render app
   end
 
   def create

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -2,22 +2,42 @@
 #
 # Table name: apps
 #
-#  id         :integer          not null, primary key
-#  creator_id :integer          not null
-#  key        :string(255)      not null
-#  secret     :string(255)      not null
-#  name       :string(255)      not null
+#  id                :integer          not null, primary key
+#  creator_id        :integer          not null
+#  key               :string(255)      not null
+#  secret            :string(255)      not null
+#  name              :string(255)      not null
+#  redirect_uri      :string(255)
+#  homepage          :string(255)
+#  description       :string(255)
+#  privileged        :boolean          default(FALSE), not null
+#  logo_file_name    :string(255)
+#  logo_content_type :string(255)
+#  logo_file_size    :integer
+#  logo_updated_at   :datetime
 #
 
 class App < ActiveRecord::Base
   belongs_to :creator, class_name: 'User'
+  has_attached_file :logo,
+    styles: { thumb: '200x200#' },
+    path: "/:class/:attachment/:id/:style.:content_type_extension",
+    default_url: "https://hummingbird.me/default_avatar.jpg",
+    processors: [:thumbnail, :paperclip_optimizer]
 
   validates :creator, presence: true
-  validates :name, presence: true, uniqueness: true
+  validates :name, presence: true, uniqueness: true, length: { in: 5..32 }
   validates :key, uniqueness: true
+  validates :redirect_uri, format: { without: %r[\Ahttp://] }
+  validates :description, length: { in: 0..140 }
+  validates_attachment :logo, content_type: {
+    content_type: ["image/jpg", "image/jpeg", "image/png"]
+  }
+
+  process_in_background :logo, processing_image_url: '/assets/processing-avatar.jpg'
 
   before_create do
-    self.key = SecureRandom.hex(10)
-    self.secret = SecureRandom.base64(30)
+    self.key = SecureRandom.hex(10) unless self.key
+    self.secret = SecureRandom.base64(30) unless self.secret
   end
 end

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -26,10 +26,10 @@ class App < ActiveRecord::Base
     processors: [:thumbnail, :paperclip_optimizer]
 
   validates :creator, presence: true
-  validates :name, presence: true, uniqueness: true, length: { in: 5..32 }
+  validates :name, presence: true, uniqueness: true, length: { maximum: 32 }
   validates :key, uniqueness: true
   validates :redirect_uri, format: { without: %r[\Ahttp://] }
-  validates :description, length: { in: 0..140 }
+  validates :description, length: { maximum: 140 }
   validates_attachment :logo, content_type: {
     content_type: ["image/jpg", "image/jpeg", "image/png"]
   }

--- a/app/serializers/app_serializer.rb
+++ b/app/serializers/app_serializer.rb
@@ -1,7 +1,8 @@
 class AppSerializer < ActiveModel::Serializer
   embed :ids
 
-  attributes :id, :key, :secret, :name
+  attributes :id, :key, :secret, :name, :homepage, :description, :redirect_uri,
+             :logo
   has_one :creator, embed_key: :name
 
   # Only show secret+key if the scope is the creator
@@ -9,4 +10,5 @@ class AppSerializer < ActiveModel::Serializer
     scope == object.creator if scope
   end
   alias_method :include_key?, :include_secret?
+  alias_method :include_redirect_uri?, :include_secret?
 end

--- a/app/serializers/app_serializer.rb
+++ b/app/serializers/app_serializer.rb
@@ -1,9 +1,9 @@
 class AppSerializer < ActiveModel::Serializer
-  embed :ids
+  embed :ids, include: true
 
   attributes :id, :key, :secret, :name, :homepage, :description, :redirect_uri,
              :logo
-  has_one :creator, embed_key: :name
+  has_one :creator, embed_key: :name, root: :users
 
   # Only show secret+key if the scope is the creator
   def include_secret?

--- a/db/migrate/20150427224114_add_o_auth_to_app.rb
+++ b/db/migrate/20150427224114_add_o_auth_to_app.rb
@@ -1,0 +1,9 @@
+class AddOAuthToApp < ActiveRecord::Migration
+  def change
+    add_column :apps, :redirect_uri, :string
+    add_column :apps, :homepage, :string
+    add_column :apps, :description, :string
+    add_column :apps, :privileged, :boolean, null: false, default: false
+    add_attachment :apps, :logo
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -157,7 +157,15 @@ CREATE TABLE apps (
     creator_id integer NOT NULL,
     key character varying(255) NOT NULL,
     secret character varying(255) NOT NULL,
-    name character varying(255) NOT NULL
+    name character varying(255) NOT NULL,
+    redirect_uri character varying(255),
+    homepage character varying(255),
+    description character varying(255),
+    privileged boolean DEFAULT false NOT NULL,
+    logo_file_name character varying(255),
+    logo_content_type character varying(255),
+    logo_file_size integer,
+    logo_updated_at timestamp without time zone
 );
 
 
@@ -3819,4 +3827,6 @@ INSERT INTO schema_migrations (version) VALUES ('20150402040627');
 INSERT INTO schema_migrations (version) VALUES ('20150426012023');
 
 INSERT INTO schema_migrations (version) VALUES ('20150504184112');
+
+INSERT INTO schema_migrations (version) VALUES ('20150427224114');
 

--- a/frontend/app/components/app-card.js
+++ b/frontend/app/components/app-card.js
@@ -1,0 +1,18 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  classNames: 'block-grid-item',
+  app: null,
+  showSecret: false,
+
+  isOwner: function() {
+    return this.get('app.creator.id') === this.get('currentUser.id');
+  }.property('app.creator', 'currentUser'),
+
+  actions: {
+    toggleSecret: function(value) {
+      value = (value === undefined) ? !this.get('showSecret') : value;
+      this.set('showSecret', value);
+    }
+  }
+});

--- a/frontend/app/components/show-errors.js
+++ b/frontend/app/components/show-errors.js
@@ -1,0 +1,17 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  clientErrors: [],
+  serverErrors: [],
+  if: true,
+  fieldName: '',
+
+  serverErrorMessages: Ember.computed.map('serverErrors', (item) => item.message),
+  shouldDisplayErrors: function() {
+    // Shorted so server errors are alwayd displayed
+    return this.get('serverErrorMessages.length') > 0 ||
+          (this.get('errors.length') && this.get('if'));
+  }.property('errors.length', 'if', 'hasServerErrors'),
+  errors: Ember.computed.union('clientErrors', 'serverErrorMessages'),
+  hasMultipleErrors: Ember.computed.gt('errors.length', 1)
+});

--- a/frontend/app/controllers/apps.js
+++ b/frontend/app/controllers/apps.js
@@ -4,6 +4,6 @@ export default Ember.Controller.extend({
   needs: ['application'],
 
   isIndex: function() {
-    return this.get('controllers.application.currentRouteName') === "apps.index";
+    return this.get('controllers.application.currentRouteName') === 'apps.index';
   }.property('controllers.application.currentRouteName'),
 });

--- a/frontend/app/controllers/apps/edit.js
+++ b/frontend/app/controllers/apps/edit.js
@@ -1,0 +1,41 @@
+import Ember from 'ember';
+import EmberValidations from 'ember-validations';
+
+export default Ember.Controller.extend(EmberValidations.Mixin, {
+  creatingApp: false,
+
+  validations: {
+    'model.name': {
+      length: {
+        minimum: 5,
+        maximum: 32
+      }
+    },
+    'model.description': {
+      length: { minimum: 0, maximum: 140, if: 'model.description' }
+    },
+    'model.redirectUri': {
+      presence: { if: 'model.writeAccess' },
+      format: {
+        without: /^http:\/\//,
+        if: 'model.writeAccess',
+        message: 'cannot use http (must be https or another protocol)'
+      }
+    }
+  },
+  // When the 'if' statements change, ember-validations doesn't notice, so we
+  // tell it ourselves.
+  forceValidate: function() {
+    this.validate();
+  }.observes('model.writeAccess'),
+
+  actions: {
+    saveApp: function() {
+      if (this.get('isValid')) {
+        this.get('model').save().then(() => {
+          this.transitionToRoute('apps.mine');
+        });
+      }
+    }
+  }
+});

--- a/frontend/app/controllers/apps/edit.js
+++ b/frontend/app/controllers/apps/edit.js
@@ -8,8 +8,9 @@ export default Ember.Controller.extend(EmberValidations.Mixin, {
     'model.name': {
       length: {
         minimum: 5,
-        maximum: 32
-      }
+        maximum: 32,
+        if: 'model.name'
+      },
     },
     'model.description': {
       length: { minimum: 0, maximum: 140, if: 'model.description' }
@@ -28,6 +29,11 @@ export default Ember.Controller.extend(EmberValidations.Mixin, {
   forceValidate: function() {
     this.validate();
   }.observes('model.writeAccess'),
+
+  isSaveDisabled: function() {
+    return this.get('isInvalid') || !this.get('model.name') ||
+           !this.get('model.description');
+  }.property('isInvalid', 'model.name', 'model.description'),
 
   actions: {
     saveApp: function() {

--- a/frontend/app/models/app.js
+++ b/frontend/app/models/app.js
@@ -1,8 +1,14 @@
 import DS from 'ember-data';
 
 export default DS.Model.extend({
+  name: DS.attr('string'),
+  creator: DS.belongsTo('user'),
   key: DS.attr('string'),
   secret: DS.attr('string'),
-  name: DS.attr('string'),
-  creator: DS.belongsTo('user')
+  homepage: DS.attr('string'),
+  description: DS.attr('string'),
+  redirectUri: DS.attr('string'),
+  writeAccess: DS.attr('boolean'),
+  logo: DS.attr('string'),
+  public: DS.attr('boolean'),
 });

--- a/frontend/app/router.js
+++ b/frontend/app/router.js
@@ -70,6 +70,7 @@ Router.map(function() {
 
   this.resource('apps', function() {
     this.route('new');
+    this.route('edit', { path: ':app_id/edit' });
     this.route('mine');
   });
   this.route('search');

--- a/frontend/app/routes/apps/edit.js
+++ b/frontend/app/routes/apps/edit.js
@@ -1,0 +1,14 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  setupController: function(controller, model) {
+    this.controllerFor('apps.edit').setProperties({
+      model: model,
+      creatingApp: false
+    });
+  },
+
+  model: function(params) {
+    return this.store.find('app', params.app_id);
+  }
+});

--- a/frontend/app/routes/apps/edit.js
+++ b/frontend/app/routes/apps/edit.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import setTitle from '../../utils/set-title';
 
 export default Ember.Route.extend({
   setupController: function(controller, model) {
@@ -10,5 +11,9 @@ export default Ember.Route.extend({
 
   model: function(params) {
     return this.store.find('app', params.app_id);
+  },
+
+  afterModel: function(model) {
+    return setTitle(`Editing ${model.get('name')}`);
   }
 });

--- a/frontend/app/routes/apps/edit.js
+++ b/frontend/app/routes/apps/edit.js
@@ -3,7 +3,7 @@ import setTitle from '../../utils/set-title';
 
 export default Ember.Route.extend({
   setupController: function(controller, model) {
-    this.controllerFor('apps.edit').setProperties({
+    controller.setProperties({
       model: model,
       creatingApp: false
     });

--- a/frontend/app/routes/apps/index.js
+++ b/frontend/app/routes/apps/index.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import setTitle from '../../utils/set-title';
 
 export default Ember.Route.extend({
   model: function() {
@@ -149,5 +150,9 @@ export default Ember.Route.extend({
   	    ]
       }
     ];
+  },
+
+  afterModel: function() {
+    return setTitle('Applications');
   }
 });

--- a/frontend/app/routes/apps/mine.js
+++ b/frontend/app/routes/apps/mine.js
@@ -1,7 +1,12 @@
 import Ember from 'ember';
+import setTitle from '../../utils/set-title';
 
 export default Ember.Route.extend({
   model: function() {
     return this.store.find('app', {creator: this.get('currentUser.id')});
+  },
+
+  afterModel: function() {
+    return setTitle('My Applications');
   }
 });

--- a/frontend/app/routes/apps/new.js
+++ b/frontend/app/routes/apps/new.js
@@ -1,0 +1,29 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  controllerName: 'apps.edit',
+
+  setupController: function(controller, model) {
+    this.controllerFor('apps.edit').setProperties({
+      model: model,
+      creatingApp: true
+    });
+  },
+
+  renderTemplate: function() {
+    this.render('apps.edit');
+  },
+
+  model: function() {
+    let currentUserUser = this.store.find('user', this.get('currentUser.id'));
+    return this.store.createRecord('app', {
+      creator: currentUserUser,
+      writeAccess: false,
+      public: false
+    });
+  },
+
+  willTransition: function() {
+    this.controllerFor('apps.edit').get('model').deleteRecord();
+  }
+});

--- a/frontend/app/routes/apps/new.js
+++ b/frontend/app/routes/apps/new.js
@@ -5,7 +5,7 @@ export default Ember.Route.extend({
   controllerName: 'apps.edit',
 
   setupController: function(controller, model) {
-    this.controllerFor('apps.edit').setProperties({
+    controller.setProperties({
       model: model,
       creatingApp: true
     });
@@ -18,6 +18,9 @@ export default Ember.Route.extend({
   model: function() {
     let currentUserUser = this.store.find('user', this.get('currentUser.id'));
     return this.store.createRecord('app', {
+      // HACK: fixes `undefined` being logged to console (bug in EV?)
+      name: '',
+      description: '',
       creator: currentUserUser,
       writeAccess: false,
       public: false

--- a/frontend/app/routes/apps/new.js
+++ b/frontend/app/routes/apps/new.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import setTitle from '../../utils/set-title';
 
 export default Ember.Route.extend({
   controllerName: 'apps.edit',
@@ -25,5 +26,9 @@ export default Ember.Route.extend({
 
   willTransition: function() {
     this.controllerFor('apps.edit').get('model').deleteRecord();
+  },
+
+  afterModel: function() {
+    return setTitle('New App');
   }
 });

--- a/frontend/app/templates/apps/edit.hbs
+++ b/frontend/app/templates/apps/edit.hbs
@@ -13,6 +13,7 @@
       </div>
       <div class="panel-body">
         <form class="form-horizontal">
+          {{!-- TODO: add logo upload button and display logo
           <div class="form-group">
             <label for="app-logo" class="col-sm-4 control-label required-label">Logo</label>
             <div class="col-sm-8">
@@ -20,6 +21,7 @@
               {{view "file-upload" action="logoSelected" id="app-logo"}}
             </div>
           </div>
+          --}}
 
           <div class="form-group {{if errors.model.name 'has-error'}}">
             <label for="app-name" class="col-sm-4 control-label required-label">Name</label>
@@ -50,6 +52,7 @@
             </div>
           </div>
 
+          {{!-- TODO: add database stuff for this
           <div class="form-group">
             <label class="col-sm-4 control-label required-label">Access</label>
             <div class="col-sm-8">
@@ -68,7 +71,9 @@
               </span>
             </div>
           </div>
+          --}}
 
+          {{!-- NOTE: enable this when we add usage tracking + dynamic /apps
           <div class="form-group">
             <label class="col-sm-4 control-label required-label">Visibility</label>
             <div class="col-sm-8">
@@ -82,7 +87,9 @@
               </label>
             </div>
           </div>
+          --}}
 
+          {{!-- NOTE: enable this when OAuth2 happens
           {{#if model.writeAccess}}
           <div class="form-group {{if errors.model.redirectUri 'has-error'}}">
               <label for="redirect-uri" class="col-sm-4 control-label required-label">Redirect URI</label>
@@ -100,6 +107,7 @@
                           clientErrors=errors.model.redirectUri
                           serverErrors=model.errors.redirectUri}}
           {{/if}}
+          --}}
 
           <div class="form-group">
             <button class="col-sm-3 col-sm-offset-3 btn btn-primary"

--- a/frontend/app/templates/apps/edit.hbs
+++ b/frontend/app/templates/apps/edit.hbs
@@ -1,0 +1,121 @@
+<div class="container">
+  <div class="col-md-8 col-md-offset-2">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h2 class="panel-title">
+          {{#if creatingApp}}
+            Create New App
+          {{else}}
+            {{!-- Unbound so it doesn't update as the user modifies the name --}}
+            Editing {{unbound model.name}}
+          {{/if}}
+        </h2>
+      </div>
+      <div class="panel-body">
+        <form class="form-horizontal">
+          <div class="form-group">
+            <label for="app-logo" class="col-sm-4 control-label required-label">Logo</label>
+            <div class="col-sm-8">
+              <img src="{{model.logoUrl}}">
+              {{view "file-upload" action="logoSelected" id="app-logo"}}
+            </div>
+          </div>
+
+          <div class="form-group {{if errors.model.name 'has-error'}}">
+            <label for="app-name" class="col-sm-4 control-label required-label">Name</label>
+            <div class="col-sm-8">
+              {{input type="text" class="form-control" id="app-name"
+                      value=model.name placeholder="Application Name"}}
+            </div>
+          </div>
+          {{show-errors if=model.name fieldName="Name" clientErrors=errors.model.name
+                        serverErrors=model.errors.name}}
+
+          <div class="form-group {{if errors.model.description 'has-error'}}">
+            <label for="app-desc" class="col-sm-4 control-label required-label">Description</label>
+            <div class="col-sm-8">
+              {{input type="text" class="form-control col-sm-8" id="app-desc"
+                      value=model.description placeholder="Description"}}
+            </div>
+          </div>
+          {{show-errors if=model.description fieldName="Description"
+                        clientErrors=errors.model.description
+                        serverErrors=model.errors.description}}
+
+          <div class="form-group">
+            <label for="app-homepage" class="col-sm-4 control-label">Homepage</label>
+            <div class="col-sm-8">
+              {{input type="url" class="form-control col-sm-8" id="app-homepage"
+                      value=model.homepage placeholder="Homepage"}}
+            </div>
+          </div>
+
+          <div class="form-group">
+            <label class="col-sm-4 control-label required-label">Access</label>
+            <div class="col-sm-8">
+              <label class="radio-inline">
+                {{radio-button value=false checked=model.writeAccess}}
+                Read Only
+              </label>
+              <label class="radio-inline">
+                {{radio-button value=true checked=model.writeAccess}}
+                Read and Write
+              </label>
+              <span class="help-block">
+                Read Only access gives you the ability to read data via APIv2.
+                Read and Write access lets users log into your app and permit
+                it to update data.
+              </span>
+            </div>
+          </div>
+
+          <div class="form-group">
+            <label class="col-sm-4 control-label required-label">Visibility</label>
+            <div class="col-sm-8">
+              <label class="radio-inline">
+                {{radio-button value=true checked=model.public}}
+                Public
+              </label>
+              <label class="radio-inline">
+                {{radio-button value=false checked=model.public}}
+                Hidden
+              </label>
+            </div>
+          </div>
+
+          {{#if model.writeAccess}}
+          <div class="form-group {{if errors.model.redirectUri 'has-error'}}">
+              <label for="redirect-uri" class="col-sm-4 control-label required-label">Redirect URI</label>
+              <div class="col-sm-8">
+                {{input type="url" class="form-control col-sm-8" id="redirect-uri"
+                        value=model.redirectUri placeholder="Redirect URI"
+                        aria-describedby="app-name-help"}}
+                <span class="help-block" id="app-name-help">
+                  Used by our <a href="#">OAuth2 provider</a> to know where to
+                  redirect back to your app.
+                </span>
+              </div>
+            </div>
+            {{show-errors if=model.redirectUri fieldName="Redirect URI"
+                          clientErrors=errors.model.redirectUri
+                          serverErrors=model.errors.redirectUri}}
+          {{/if}}
+
+          <div class="form-group">
+            <button class="col-sm-3 col-sm-offset-3 btn btn-primary"
+                    {{action 'saveApp'}} disabled={{isInvalid}}>
+              {{#if creatingApp}}
+                Create
+              {{else}}
+                Save
+              {{/if}}
+            </button>
+            {{#link-to 'apps.mine' class='col-sm-3 btn btn-default'}}
+              Cancel
+            {{/link-to}}
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/app/templates/apps/edit.hbs
+++ b/frontend/app/templates/apps/edit.hbs
@@ -111,7 +111,7 @@
 
           <div class="form-group">
             <button class="col-sm-3 col-sm-offset-3 btn btn-primary"
-                    {{action 'saveApp'}} disabled={{isInvalid}}>
+                    {{action 'saveApp'}} disabled={{isSaveDisabled}}>
               {{#if creatingApp}}
                 Create
               {{else}}

--- a/frontend/app/templates/apps/mine.hbs
+++ b/frontend/app/templates/apps/mine.hbs
@@ -1,17 +1,11 @@
-<h2>My Apps</h2>
+<h2>
+  My Apps
+  {{#link-to 'apps.new' class='btn btn-default pull-right'}}
+    <i class="fa fa-plus"></i> New App
+  {{/link-to}}
+</h2>
 <div class="block-grid-md-2 blog-grid-sm-1">
   {{#each model as |app|}}
     {{app-card app=app}}
   {{/each}}
-  <div class="block-grid-item">
-    <div class="app-card app-card-new">
-      <div class="app-inner">
-        <h3 class="app-title">New App</h3>
-        <div class="app-card-new-form-container">
-          {{input type="text" class="form-control" name="name" value=newAppName placeholder="Application Name"}}
-          <button class="btn" {{action "createApp"}}>Create</button>
-        </div>
-      </div>
-    </div>
-  </div>
 </div>

--- a/frontend/app/templates/apps/mine.hbs
+++ b/frontend/app/templates/apps/mine.hbs
@@ -1,19 +1,7 @@
 <h2>My Apps</h2>
 <div class="block-grid-md-2 blog-grid-sm-1">
   {{#each model as |app|}}
-    <div class="block-grid-item">
-      <div class="app-card">
-        <div class="app-inner">
-          <h3 class="app-title">{{app.name}}</h3>
-          <dl>
-            <dt>Key</dt>
-            <dd class="app-token">{{app.key}}</dd>
-            <dt>Secret</dt>
-            <dd class="app-token">{{app.secret}}</dd>
-          </dl>
-        </div>
-      </div>
-    </div>
+    {{app-card app=app}}
   {{/each}}
   <div class="block-grid-item">
     <div class="app-card app-card-new">

--- a/frontend/app/templates/components/app-card.hbs
+++ b/frontend/app/templates/components/app-card.hbs
@@ -1,0 +1,45 @@
+<div class="app-card">
+  <div class="app-inner">
+    <h3 class="app-title">
+      {{app.name}}
+      {{#link-to 'apps.edit' app class='btn btn-default app-type pull-right'}}
+        Edit
+      {{/link-to}}
+    </h3>
+    <small class="app-author">by
+      {{#link-to 'user' app.creator}}
+        {{app.creator.username}}
+      {{/link-to}}
+    </small>
+    <hr>
+    <p class="app-desc">
+      {{app.description}}
+    </p>
+    {{#if isOwner}}
+      <dl class="app-keys">
+        {{#if app.key}}
+          <dt class="col-sm-2">Key</dt>
+          <dd class="col-sm-10">
+            <span class="form-control-static app-token">{{app.key}}</span>
+          </dd>
+        {{/if}}
+        {{#if app.secret}}
+          <dt class="col-sm-2">Secret</dt>
+          <dd class="col-sm-10">
+            {{#if showSecret}}
+              <span class="form-control-static app-token">{{app.secret}}</span>
+            {{else}}
+              <button class="btn btn-default btn-xs"
+                      {{action 'toggleSecret' true}}>
+                Show
+              </button>
+            {{/if}}
+          </dd>
+        {{/if}}
+      </dl>
+    {{/if}}
+    <div class="app-link">
+      <a href="{{app.website}}">Website</a>
+    </div>
+  </div>
+</div>

--- a/frontend/app/templates/components/show-errors.hbs
+++ b/frontend/app/templates/components/show-errors.hbs
@@ -1,0 +1,15 @@
+{{#if shouldDisplayErrors}}
+  <div class="alert alert-danger" role="alert">
+    {{#if hasMultipleErrors}}
+      <ul>
+        {{#each errors as |message|}}
+          <li>{{fieldName}} {{message}}</li>
+        {{/each}}
+      </ul>
+    {{else}}
+      {{#each errors as |message|}}
+        {{fieldName}} {{message}}
+      {{/each}}
+    {{/if}}
+  </div>
+{{/if}}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,7 @@
     "ember-cli-rails-addon": "0.0.11",
     "ember-cli-uglify": "1.0.1",
     "ember-data": "^1.0.0-beta.16.1",
-    "ember-export-application-global": "^1.0.2"
+    "ember-export-application-global": "^1.0.2",
+    "ember-validations": "2.0.0-alpha.3"
   }
 }

--- a/test/controllers/apps_controller_test.rb
+++ b/test/controllers/apps_controller_test.rb
@@ -1,0 +1,97 @@
+require 'test_helper'
+
+class AppsControllerTest < ActionController::TestCase
+  let(:josh) { users(:josh) }
+
+  test 'can show your apps' do
+    create(:app, creator: josh)
+
+    sign_in josh
+    get :mine
+    assert_response 200
+    assert_preloaded "apps"
+  end
+
+  test 'can get all apps by creator' do
+    create(:app, creator: josh)
+
+    sign_in josh
+    get :index, format: :json, creator: josh.id
+    assert_response 200
+    assert_json_body({
+      users: Array,
+      apps: [
+        {
+          key: String,
+          secret: String,
+          name: String
+        }
+      ]
+    })
+  end
+
+  test 'can get the data for a single app' do
+    app = create(:app, creator: josh)
+
+    sign_in josh
+    get :show, format: :json, id: app.id
+    assert_response 200
+    assert_json_body({
+      users: Array,
+      app: {
+        key: String,
+        secret: String,
+        name: String
+      }
+    })
+  end
+
+  test 'can create a new app' do
+    sign_in josh
+
+    # Generate the JSON in a helper method for the serialized version
+    post :create, {
+      app: {
+        name: Faker::App.name,
+        homepage: Faker::Internet.url,
+        description: Faker::Lorem.sentence
+      }
+    }
+    assert_response 200
+  end
+
+  test 'can edit an existing app if creator' do
+    app = create(:app, creator: josh)
+    sign_in josh
+
+    new_name = Faker::Lorem.word
+    post :update, {
+      id: app.id,
+      app: {
+       name: new_name
+      }
+    }
+    assert_response 200
+    assert_json_body({
+      users: Array,
+      app: {
+        key: String,
+        secret: String,
+        name: new_name
+      }
+    })
+  end
+
+  test 'cannot edit an existing app if not creator' do
+    app = create(:app, creator: josh)
+    sign_in users(:vikhyat)
+
+    post :update, {
+      id: app.id,
+      app: {
+        name: 'TOP KEK'
+      }
+    }
+    assert_response 403
+  end
+end

--- a/test/factories/apps.rb
+++ b/test/factories/apps.rb
@@ -2,15 +2,25 @@
 #
 # Table name: apps
 #
-#  id         :integer          not null, primary key
-#  creator_id :integer          not null
-#  key        :string(255)      not null
-#  secret     :string(255)      not null
-#  name       :string(255)      not null
+#  id                :integer          not null, primary key
+#  creator_id        :integer          not null
+#  key               :string(255)      not null
+#  secret            :string(255)      not null
+#  name              :string(255)      not null
+#  redirect_uri      :string(255)
+#  homepage          :string(255)
+#  description       :string(255)
+#  privileged        :boolean          default(FALSE), not null
+#  logo_file_name    :string(255)
+#  logo_content_type :string(255)
+#  logo_file_size    :integer
+#  logo_updated_at   :datetime
 #
 
 FactoryGirl.define do
   factory :app do
     name { Faker::App.name }
+    key { SecureRandom.hex(10) }
+    secret { SecureRandom.base64(30) }
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,6 +15,10 @@ require 'webmock_helper'
 
 require 'mocha/mini_test'
 
+require 'json_expressions/minitest'
+JsonExpressions::Matcher.assume_strict_arrays = false
+JsonExpressions::Matcher.assume_strict_hashes = false
+
 $redis = ConnectionPool.new { MockRedis.new }
 
 class ActiveSupport::TestCase
@@ -33,5 +37,9 @@ class ActionController::TestCase
 
   def assert_preloaded(key)
     assert JSON.parse(assigns["preload"].to_json).map {|x| x.keys }.flatten.include?(key), "#{key} should be preloaded"
+  end
+
+  def assert_json_body(matcher)
+    assert_json_match(matcher, @response.body)
   end
 end


### PR DESCRIPTION
This is the precursor to the OAuth2 stuff.

This adds fields to the `App` model which we'll need for OAuth2 (redirect uri, logo, etc.) and updates the UI to handle the increase in fields — namely by switching to a separate edit/create route instead of using an inline create card.  Oh, and you can edit apps now.  Cool stuff.

Along the way I added a `save_and_render` helper which will save a model and handle responding with either the model or the errors in ED form and made it so `ember_action` can now be called without a block to just hand off to Ember without preloading.

On the testing side of things I added `guard-minitest` so we can now just start `guard` and it'll monitor and run the tests, tweaked the defaults on `json_expressions` so it's "loose" by default (ie, we don't have to spec the entire object, just what matters to our test), and added `assert_json_body` along the lines of `assert_preloaded` and our other assertion shorthands.