### PR TITLE
Hacky workaround for `nil` in user array

### DIFF
--- a/lib/story_query.rb
+++ b/lib/story_query.rb
@@ -69,7 +69,7 @@ class StoryQuery
     users += substories.map(&:user)
     users += substories.select {|x| x.target_type == "User" }.map(&:target)
     users += recent_users.values
-    users = users.uniq
+    users = users.uniq.compact
     UserQuery.load_is_followed(users, current_user)
 
     # Return stories in the same order as the IDs.


### PR DESCRIPTION
On josh's profile feed, somehow `nil` got into the user loading array, causing his feed to 500.  This is a hacky workaround for that, which just removes `nil` from the array instead of actually tracking down the root cause.

An edgecase like this isn't worth our time or effort to find the root cause right now.