### PR TITLE
Change "video.tv_episode" to "video.other"

### DIFF
--- a/app/views/anime/show.html.erb
+++ b/app/views/anime/show.html.erb
@@ -4,7 +4,7 @@
   <% elsif ["OVA", "ONA", "TV"].include? @anime.show_type %>
     <meta property="og:type" content="video.tv_show">
   <% else %>
-    <meta property="og:type" content="video.tv_episode">
+    <meta property="og:type" content="video.other">
   <% end %>
 
   <meta property="og:url" content="<%= anime_url(@anime) %>">


### PR DESCRIPTION
`video.tv_episode` is not a valid type according to [The Open Graph protocol documentation](http://ogp.me/#type_video). `video.other` is the only suitable video type as Specials and Music are not tv shows (`video.tv_show`) or episodes (`video.episode`).

---

>video.other
>
>A video that doesn't belong in any other category. The metadata is identical to `video.movie`