### PR TITLE
Fix MAL Importer Prefixing "Edit" To Synopsis

### DIFF
--- a/lib/mal_import.rb
+++ b/lib/mal_import.rb
@@ -102,7 +102,7 @@ class MALImport
         ja_jp: begin @sidebar.css('div:contains("Japanese:")')[0].text.gsub("Japanese: ", "") rescue nil end
       }.compact,
       synopsis: begin
-        synopsis = @main_noko.css('td td:contains("Synopsis")')[0].text.gsub("Synopsis", '').split("googletag.cmd.push")[0]
+        synopsis = @main_noko.css('td td:contains("Synopsis")')[0].text.gsub("EditSynopsis", '').split("googletag.cmd.push")[0]
         if synopsis.include? "No synopsis has been added"
           nil
         else


### PR DESCRIPTION
MAL recently changed the anime page to include links that were previously hidden if you were logged out - thus adding a `div` containing `Edit` which doesn't get stripped out by Hummingbird.

Fixes this:

![](http://i.imgur.com/UGPUc3c.png)