### PR TITLE
Rake task for anime images download

### DIFF
--- a/lib/tasks/hb.rake
+++ b/lib/tasks/hb.rake
@@ -28,18 +28,12 @@ namespace :hummingbird do
         puts "#{anime.title} - \033[31mNo image found, downloading…\033[0m"
 
         remote_url = open(
-          "https://hummingbird.me/full_anime/#{anime.slug}.json",
-          ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE
+          "https://hummingbird.me/full_anime/#{anime.slug}.json"
         ).read
         remote_anime = JSON.parse(remote_url)['full_anime']
 
-        anime.update_from_pending(
-          anime.create_pending(
-            User.first,
-            type => remote_anime[type.to_s],
-            edit_comment: 'Rake automatic image download'
-          )
-        )
+        anime.update_attributes(type => remote_anime[type.to_s])
+
       end
     end
   end

--- a/lib/tasks/hb.rake
+++ b/lib/tasks/hb.rake
@@ -1,0 +1,36 @@
+namespace :hummingbird do
+  desc 'Download images from Hummingbird for better development'
+  task images: 'images:anime'
+
+  namespace :images do
+    desc 'Download anime cover images, to test listings'
+    task :anime, [:quantity] => [:environment] do |_t, args|
+      args.with_defaults(quantity: 72)
+      Anime.order_by_rating.limit(args.quantity).each do |anime|
+        print anime.title
+
+        if File.exist? anime.cover_image.path
+          puts " - \033[32mImage already downloaded\033[0m"
+          next
+        end
+
+        puts " - \033[31mNo image found, starting download…\033[0m"
+
+        remote_url = open(
+          "https://hummingbird.me/full_anime/#{anime.slug}.json",
+          ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE
+        ).read
+        remote_anime = JSON.parse(remote_url)['full_anime']
+
+        anime.update_from_pending(
+          anime.create_pending(
+            User.first,
+            cover_image: remote_anime['cover_image'],
+            poster_image: remote_anime['poster_image'],
+            edit_comment: 'Rake automatic image download'
+          )
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
With the current DB dump used for dev install, we don't got the anime images needed to correctly display the lists and individual anime pages (well, quite obvious, but still…), so I created a simple task to handle this:

```
rake hummingbird:images                    # Download images from Hummingbird for better development
rake hummingbird:images:covers[quantity]   # Download only anime covers
rake hummingbird:images:posters[quantity]  # Download only anime posters
```

By default it get images from 2 pages from default listing. If more (or less) images are needed, you can specify the value on each individual task.

If needed, we can add more complex tasks in the future (get images by genre, date, by individual id, casts, etc)