### PR TITLE
Manga Poster image adjustment

### DIFF
--- a/app/models/manga.rb
+++ b/app/models/manga.rb
@@ -69,8 +69,15 @@ class Manga < ActiveRecord::Base
     content_type: ["image/jpg", "image/jpeg", "image/png", "image/gif"]
   }
 
-  has_attached_file :poster_image, default_url: "/assets/missing-anime-cover.jpg",
-    styles: {large: "200x290!", medium: "100x150!"},
+  has_attached_file :poster_image,
+    styles: {
+      large: {geometry: '490x710!', animated: false, format: :jpg},
+      medium: '100x150!'
+    },
+    convert_options: {
+      large: '-quality 0'
+    },
+    default_url: '/assets/missing-anime-cover.jpg',
     keep_old_files: true
 
   validates_attachment :poster_image, content_type: {


### PR DESCRIPTION
This is my first pull request to hummingbird so forgive me, since I am still trying to familiarize myself with the codebase!

In reference to Issue #553, the manga poster size was not kosher with the anime poster size. After reviewing the forum post:

 https://forums.hummingbird.me/t/increase-manga-posters-images-resolution/24533

It seemed it had just been forgotten, so I updated the manga.rb to reflect the changes in anime.rb.

I also updated the default-path to the 'missing-anime-cover.jpg' in both the models on another commit,  since that seemed local enough to include without needing its own request.