### PR TITLE
Fix overflow issue with show more on followed stories

### DIFF
--- a/app/assets/stylesheets/partials/status-panel.css.scss
+++ b/app/assets/stylesheets/partials/status-panel.css.scss
@@ -194,11 +194,7 @@
     &.full-post {
       max-height: none;
     }
-      
-    .follow-bubbles {
-      max-height: 480px;
-      overflow: auto;
-    }
+
   }
 
   .event-info {

--- a/app/assets/stylesheets/partials/status-panel.css.scss
+++ b/app/assets/stylesheets/partials/status-panel.css.scss
@@ -194,6 +194,11 @@
     &.full-post {
       max-height: none;
     }
+      
+    .follow-bubbles {
+      max-height: 480px;
+      overflow: auto;
+    }
   }
 
   .event-info {

--- a/app/assets/stylesheets/partials/user-activity-feed.css.scss
+++ b/app/assets/stylesheets/partials/user-activity-feed.css.scss
@@ -453,6 +453,8 @@
   padding-left: 15px;
   padding-right: 15px;
   margin-top: 15px;
+  max-height: 480px;
+  overflow: auto;
 
   li {
     @extend .col-sm-6;


### PR DESCRIPTION
In reference to issue #416 :)

Here is how it looks like after clicking on "Show more", there is now a scrollbar to see everything :

![screen_follow-show-more](https://cloud.githubusercontent.com/assets/5560784/8005768/dc3423e2-0b8d-11e5-80bc-907dba95b7e6.png)
