### PR TITLE
Add Twitter cards to anime pages

### DIFF
--- a/app/views/anime/show.html.erb
+++ b/app/views/anime/show.html.erb
@@ -10,6 +10,14 @@
   <meta property="og:url" content="<%= anime_url(@anime) %>">
   <meta property="og:description" content="<%= @anime.synopsis.gsub('"', '\\"') %>">
   <meta property="og:image" content="<%= @anime.poster_image.url %>">
+  <% if @anime.cover_image.file? %>
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:image" content="<%= @anime.cover_image.url %>">
+  <% else %>
+    <meta name="twitter:card" content="summary">
+  <% end %>
+  <meta name="twitter:site" content="@hummingbird_me">
+  <meta name="twitter:title" content="<%= @anime.canonical_title %>">
 <% end %>
 <% content_for :body do %>
   <div class="container bg-image" itemscope itemtype="http://schema.org/TVSeries">


### PR DESCRIPTION
Twitter Cards: https://dev.twitter.com/cards/overview

Displays the cover image when available:
![](https://cloud.githubusercontent.com/assets/1078430/8006472/ec2ddd74-0b9c-11e5-97c7-ee3a28bf8dc1.png)

Falls back to the poster image (provided by `og:image`) otherwise:
![](https://cloud.githubusercontent.com/assets/1078430/8006474/f1daad1a-0b9c-11e5-8939-f3bb8d0891df.png)