### PR TITLE
Create Media concern to DRY Anime and Manga models

### DIFF
--- a/app/models/concerns/media.rb
+++ b/app/models/concerns/media.rb
@@ -1,0 +1,83 @@
+module Media
+  extend ActiveSupport::Concern
+  included do
+    include Versionable
+    include BayesianAverageable
+    include PgSearch
+    extend FriendlyId
+
+    has_and_belongs_to_many :genres
+    with_options(dependent: :destroy) do |a|
+      a.has_many :castings, as: :castable
+      a.has_many :favorites, as: :item
+    end
+
+    VALID_IMAGES = %w(image/jpg image/jpeg image/png image/gif)
+
+    has_attached_file :cover_image,
+                      styles: { thumb: ['1400x900>', :jpg] },
+                      convert_options: { thumb: '-quality 90' },
+                      keep_old_files: true
+
+    has_attached_file :poster_image,
+                      styles: {
+                        large: {
+                          geometry: '490x710!',
+                          animated: false,
+                          format: :jpg
+                        },
+                        medium: '100x150!'
+                      },
+                      convert_options: { large: '-quality 0' },
+                      default_url: '/assets/missing-anime-cover.jpg',
+                      keep_old_files: true
+
+    validates_attachment_content_type :cover_image,
+                                      :poster_image,
+                                      content_type: self::VALID_IMAGES
+
+    pg_search_scope :instant_search,
+                    against: self::PG_TITLE_SCOPE,
+                    using: {
+                      tsearch: {
+                        normalization: 42,
+                        prefix: true,
+                        dictionary: 'english'
+                      }
+                    }
+
+    pg_search_scope :full_search,
+                    against: self::PG_TITLE_SCOPE,
+                    using: {
+                      tsearch: {
+                        normalization: 42,
+                        dictionary: 'english'
+                      },
+                      trigram: { threshold: 0.1 }
+                    },
+                    # Combine trigram and tsearch values
+                    ranked_by: ':tsearch + :trigram'
+
+    def poster_image_thumb(size = :large)
+      if poster_image_file_name.nil?
+        return 'https://hummingbird.me/assets/missing-anime-cover.jpg'
+      end
+
+      # This disgusting fastpath brought to you by the following issue:
+      # https://github.com/thoughtbot/paperclip/issues/909
+      # When fixed, use poster_image.url(size)
+
+      host = '/uploads/'
+      host = 'https://static.hummingbird.me/' if Rails.env.production?
+      image = URI.escape(poster_image_file_name)
+      # Force .jpg extension on large files
+      image.gsub!(/.{3}$/, 'jpg') if size == :large
+      # generate 000/000/000 path pattern based on id
+      hash = id.to_s.rjust(9, '0').scan(/.{3}/).join('/')
+      media = self.class.to_s.downcase
+      updated = poster_image_updated_at.to_i
+
+      "#{host}#{media}/poster_images/#{hash}/#{size}/#{image}?#{updated}"
+    end
+  end
+end

--- a/app/models/manga.rb
+++ b/app/models/manga.rb
@@ -31,80 +31,21 @@
 #
 
 class Manga < ActiveRecord::Base
-  include Versionable
-  include BayesianAverageable
-
-  include PgSearch
-  pg_search_scope :instant_search,
-    against: [ :romaji_title, :english_title ],
-    using: { tsearch: { normalization: 42, dictionary: 'english' } },
-    ranked_by: ':tsearch'
-  pg_search_scope :full_search,
-    against: [ :romaji_title, :english_title ],
-    using: {
-      tsearch: { normalization: 42, dictionary: 'english' },
-      trigram: { threshold: 0.1 }
-    },
-    ranked_by: ':tsearch + :trigram'
-
-  extend FriendlyId
-  friendly_id :romaji_title, use: [:slugged, :history]
-
-  # Internal Constants
-  private
+  PG_TITLE_SCOPE = %i(romaji_title english_title)
 
   VALID_TYPES =  ["Manga", "Novel", "One Shot", "Doujin", "Manhwa", "Manhua", "OEL"]
 
-  public
+  include Media
+
+  friendly_id :romaji_title, use: %i(slugged history)
+
+  has_many :manga_library_entries, dependent: :destroy
 
   validates :romaji_title, presence: true
   validates :manga_type, inclusion: { in: VALID_TYPES }
 
-  has_attached_file :cover_image,
-    styles: {thumb: ["1400x900>", :jpg]},
-    convert_options: {thumb: "-quality 70"},
-    keep_old_files: true
-
-  validates_attachment :cover_image, content_type: {
-    content_type: ["image/jpg", "image/jpeg", "image/png", "image/gif"]
-  }
-
-  has_attached_file :poster_image,
-    styles: {
-      large: {geometry: '490x710!', animated: false, format: :jpg},
-      medium: '100x150!'
-    },
-    convert_options: {
-      large: '-quality 0'
-    },
-    default_url: '/assets/missing-anime-cover.jpg',
-    keep_old_files: true
-
-  validates_attachment :poster_image, content_type: {
-    content_type: ["image/jpg", "image/jpeg", "image/png", "image/gif"]
-  }
-
-  has_many :favorites, dependent: :destroy, as: :item
-  has_many :castings, dependent: :destroy, as: :castable
-  has_and_belongs_to_many :genres
-  has_many :manga_library_entries, dependent: :destroy
-
   def canonical_title
     romaji_title
-  end
-
-  def poster_image_thumb
-    if self.poster_image_file_name.nil?
-      "https://hummingbird.me/assets/missing-anime-cover.jpg"
-    else
-      # This disgusting fastpath brought to you by the following issue:
-      # https://github.com/thoughtbot/paperclip/issues/909
-      if Rails.env.production?
-        "https://static.hummingbird.me/manga/poster_images/#{"%03d" % (self.id/1000000 % 1000)}/#{"%03d" % (self.id/1000 % 1000)}/#{"%03d" % (self.id % 1000)}/large/#{self.poster_image_file_name}?#{self.poster_image_updated_at.to_i}"
-      else
-        self.poster_image.url(:large)
-      end
-    end
   end
 
   def self.create_or_update_from_hash hash

--- a/app/models/manga.rb
+++ b/app/models/manga.rb
@@ -33,7 +33,7 @@
 class Manga < ActiveRecord::Base
   PG_TITLE_SCOPE = %i(romaji_title english_title)
 
-  VALID_TYPES =  ["Manga", "Novel", "One Shot", "Doujin", "Manhwa", "Manhua", "OEL"]
+  VALID_TYPES =  ['Manga', 'Novel', 'One Shot', 'Doujin', 'Manhwa', 'Manhua', 'OEL']
 
   include Media
 


### PR DESCRIPTION
The title is pretty straight forward. My first thought was to mode paperclip related methods inside a concern, but I saw many other methods that we could DRY, so I made a concern grouping all duplicated code. 

I think the concern has the right size, but if you guys like we can split this concern into Media and MediaImage concerns