### PR TITLE
Serve smaller cover images to Twitter

### DIFF
--- a/app/views/anime/show.html.erb
+++ b/app/views/anime/show.html.erb
@@ -12,7 +12,7 @@
   <meta property="og:image" content="<%= @anime.poster_image.url %>">
   <% if @anime.cover_image.file? %>
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:image" content="<%= @anime.cover_image.url %>">
+    <meta name="twitter:image" content="<%= @anime.cover_image.url(:thumb) %>">
   <% else %>
     <meta name="twitter:card" content="summary">
   <% end %>


### PR DESCRIPTION
This is a follow-up to #572.

Hummingbird's cards are now [showing up on Twitter](https://twitter.com/search?q=hummingbird.me%2Fanime), but not for all anime. I'm not sure if this is the reason, but according to their documentation, "images must be less than 1MB in size". In any case, I think there's no reason to serve Twitterbot a [7034x1997px 300dpi 5.6MB image](https://static.hummingbird.me/anime/cover_images/000/003/128/original/620663-SOUL.EATER.full.559429_(1).jpg?1416243168)...