### PR TITLE
Use ||= for constant declarations

### DIFF
--- a/app/models/concerns/media.rb
+++ b/app/models/concerns/media.rb
@@ -12,7 +12,7 @@ module Media
       a.has_many :favorites, as: :item
     end
 
-    VALID_IMAGES = %w(image/jpg image/jpeg image/png image/gif)
+    VALID_IMAGES ||= %w(image/jpg image/jpeg image/png image/gif)
 
     has_attached_file :cover_image,
                       styles: { thumb: ['1400x900>', :jpg] },


### PR DESCRIPTION
This prevents "already initialized constant" warnings when Rails reloads the class.  Sadly there doesn't seem to be anything in rubocop to make this reminder automatic.

We should send this upstream to rubocop and take note of this in future PRs.  Also it looks like this might not apply to things inheriting from Rails-provided objects.