### PR TITLE
Fix paperclip thumb generation

### DIFF
--- a/app/api/api_v1.rb
+++ b/app/api/api_v1.rb
@@ -99,7 +99,7 @@ class API_v1 < Grape::API
           alternate_title: anime.alternate_title(title_language_preference),
           episode_count: anime.episode_count,
           episode_length: anime.episode_length,
-          cover_image: anime.poster_image_thumb,
+          cover_image: anime.poster_image.url(:large),
           synopsis: anime.synopsis,
           show_type: anime.show_type,
           started_airing: anime.started_airing_date,

--- a/app/models/anime.rb
+++ b/app/models/anime.rb
@@ -364,7 +364,7 @@ class Anime < ActiveRecord::Base
     # check if URL is the same, otherwise paperclip will determine
     # that it is a new image based on `original` filesize compared to
     # the linked thumbnail filesize.
-    obj.delete(:poster_image) if obj[:poster_image] == poster_image_thumb
+    obj.delete(:poster_image) if obj[:poster_image] == poster_image.url(:large)
     obj.delete(:cover_image) if obj[:cover_image] == cover_image.url(:thumb)
 
     obj[:started_airing_date] = obj.delete(:started_airing)

--- a/app/models/concerns/media.rb
+++ b/app/models/concerns/media.rb
@@ -57,27 +57,5 @@ module Media
                     },
                     # Combine trigram and tsearch values
                     ranked_by: ':tsearch + :trigram'
-
-    def poster_image_thumb(size = :large)
-      if poster_image_file_name.nil?
-        return 'https://hummingbird.me/assets/missing-anime-cover.jpg'
-      end
-
-      # This disgusting fastpath brought to you by the following issue:
-      # https://github.com/thoughtbot/paperclip/issues/909
-      # When fixed, use poster_image.url(size)
-
-      host = '/uploads/'
-      host = 'https://static.hummingbird.me/' if Rails.env.production?
-      image = URI.escape(poster_image_file_name)
-      # Force .jpg extension on large files
-      image.gsub!(/.{3}$/, 'jpg') if size == :large
-      # generate 000/000/000 path pattern based on id
-      hash = id.to_s.rjust(9, '0').scan(/.{3}/).join('/')
-      media = self.class.to_s.downcase
-      updated = poster_image_updated_at.to_i
-
-      "#{host}#{media}/poster_images/#{hash}/#{size}/#{image}?#{updated}"
-    end
   end
 end

--- a/app/serializers/anime_serializer.rb
+++ b/app/serializers/anime_serializer.rb
@@ -22,7 +22,7 @@ class AnimeSerializer < ActiveModel::Serializer
     if !object.sfw? && (scope.nil? || scope.try(:sfw_filter))
       "/assets/missing-anime-cover.jpg"
     else
-      object.poster_image_thumb
+      object.poster_image.url(:large)
     end
   end
 

--- a/app/serializers/api/v2/anime_serializer.rb
+++ b/app/serializers/api/v2/anime_serializer.rb
@@ -15,7 +15,7 @@ module Api::V2
       :youtube_video_id, :age_rating, :episode_count, :episode_length,
       :show_type
 
-    field(:poster_image) {|a| a.poster_image_thumb }
+    field(:poster_image) {|a| a.poster_image.url(:large) }
     field(:cover_image) {|a| a.cover_image.url(:thumb) }
     field(:community_rating) {|a| a.bayesian_rating }
     field(:genres) {|a| a.genres.map {|x| x.name } }

--- a/config/initializers/paperclip-interpolations.rb
+++ b/config/initializers/paperclip-interpolations.rb
@@ -1,0 +1,13 @@
+# This module monkeypath paperclip, for faster url generation
+# https://github.com/thoughtbot/paperclip/issues/909
+# https://github.com/thoughtbot/paperclip/pull/916
+
+module Paperclip
+  module Interpolations
+    def self.interpolate(pattern, *args)
+      pattern.gsub /:([[:word:]]+)/ do
+        Paperclip::Interpolations.respond_to?($1) ? Paperclip::Interpolations.send($1, *args) : ":#{$1}"
+      end
+    end
+  end
+end

--- a/lib/onebox/engine/hummingbird_onebox.rb
+++ b/lib/onebox/engine/hummingbird_onebox.rb
@@ -17,7 +17,7 @@ module Onebox
               </div>
             </div>
             <div class="onebox-body media-embed">
-              <img src="#{media.poster_image_thumb}" class="thumbnail">
+              <img src="#{media.poster_image.url(:large)}" class="thumbnail">
               <h3><a href="#{@url}" target="_blank">#{media.canonical_title}</a></h3>
               <h4>#{media.genres.map {|x| x.name }.sort * ", "}</h4>
               #{media.synopsis[0..199]}...


### PR DESCRIPTION
`poster_image_thumb` was a method used to solve a problem on paperclip gem. My last attempt to fix it fixed small images, but added a bug on images with `.jpeg` extension.

Talking with @NuckChorris we decided that was better to monkeypatch the gem rather than trying to create a method to cover all images possibilities.