### PR TITLE
Cleanup indices

### DIFF
--- a/db/migrate/20150712193314_index_cleanup.rb
+++ b/db/migrate/20150712193314_index_cleanup.rb
@@ -1,0 +1,15 @@
+class IndexCleanup < ActiveRecord::Migration
+  def change
+    # Extremely common operations
+    add_index :reviews, :user_id
+    add_index :reviews, :anime_id
+    add_index :recommendations, :user_id
+
+    # WTF?
+    remove_index :users, :waifu_or_husbando
+    remove_index :users, :waifu_slug
+
+    # Used on Kotodama only, but avoids 6-second load times
+    add_index :substories, :created_at
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2903,6 +2903,27 @@ CREATE INDEX index_quotes_on_anime_id ON quotes USING btree (anime_id);
 
 
 --
+-- Name: index_recommendations_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_recommendations_on_user_id ON recommendations USING btree (user_id);
+
+
+--
+-- Name: index_reviews_on_anime_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_reviews_on_anime_id ON reviews USING btree (anime_id);
+
+
+--
+-- Name: index_reviews_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_reviews_on_user_id ON reviews USING btree (user_id);
+
+
+--
 -- Name: index_stories_on_created_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -2928,6 +2949,13 @@ CREATE INDEX index_stories_on_group_id ON stories USING btree (group_id);
 --
 
 CREATE INDEX index_stories_on_user_id ON stories USING btree (user_id);
+
+
+--
+-- Name: index_substories_on_created_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_substories_on_created_at ON substories USING btree (created_at);
 
 
 --
@@ -3012,20 +3040,6 @@ CREATE INDEX index_users_on_waifu ON users USING btree (waifu);
 --
 
 CREATE INDEX index_users_on_waifu_char_id ON users USING btree (waifu_char_id);
-
-
---
--- Name: index_users_on_waifu_or_husbando; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_users_on_waifu_or_husbando ON users USING btree (waifu_or_husbando);
-
-
---
--- Name: index_users_on_waifu_slug; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_users_on_waifu_slug ON users USING btree (waifu_slug);
 
 
 --
@@ -3833,4 +3847,6 @@ INSERT INTO schema_migrations (version) VALUES ('20150504184112');
 INSERT INTO schema_migrations (version) VALUES ('20150427224114');
 
 INSERT INTO schema_migrations (version) VALUES ('20150204092920');
+
+INSERT INTO schema_migrations (version) VALUES ('20150712193314');
 


### PR DESCRIPTION
Tweaks to our indexing situation discovered via pghero and mini-profiler in production.

For the most part, these added indices shouldn't make a noticeable difference in load times.  `recommendations` may benefit, but `reviews` is such a small table that the current seq scan doesn't add more than about 15ms to the anime endpoint.

The `created_at` on `substories` should reduce the kotodama load time quite a bit (hoping to shave off about 5 seconds there)

There were also two completely nonsensical and pointless indices on the `users` table for `waifu_slug` and `waifu_or_husbando`.  We've never had any queries based on those, and I can't imagine ever needing them, so I removed them.