### PR TITLE
Refactor minitest

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'
+require 'coffee_script'
 
 # require_dependency doesn't work here for some reason.
 require_relative '../lib/log_before_timeout.rb'

--- a/lib/tasks/test_directories.rake
+++ b/lib/tasks/test_directories.rake
@@ -1,16 +1,13 @@
 namespace :test do
-  task run: %w(
-    test:units test:functionals test:generators test:integration
-    test:services test:libs
-  )
-
   desc 'test services'
   Rails::TestTask.new(services: 'test:prepare') do |t|
     t.pattern = 'test/services/**/*_test.rb'
   end
 
-  desc 'test libs'
-  Rails::TestTask.new(libs: 'test:prepare') do |t|
+  desc 'test lib'
+  Rails::TestTask.new(lib: 'test:prepare') do |t|
     t.pattern = 'test/lib/**/*_test.rb'
   end
 end
+
+Rake::Task['test:run'].enhance ['test:lib', 'test:services']

--- a/lib/tasks/test_directories.rake
+++ b/lib/tasks/test_directories.rake
@@ -1,20 +1,16 @@
 namespace :test do
-  desc "test lib"
-  Rake::TestTask.new(:lib) do |t|
-    t.libs << "test"
-    t.pattern = 'test/lib/**/*_test.rb'
-    t.verbose = true
-  end
+  task run: %w(
+    test:units test:functionals test:generators test:integration
+    test:services test:libs
+  )
 
-  desc "test services"
-  Rake::TestTask.new(:services) do |t|
-    t.libs << "test"
+  desc 'test services'
+  Rails::TestTask.new(services: 'test:prepare') do |t|
     t.pattern = 'test/services/**/*_test.rb'
-    t.verbose = true
   end
-end
 
-Rake::Task[:test].enhance do
-  Rake::Task["test:lib"].invoke
-  Rake::Task["test:services"].invoke
+  desc 'test libs'
+  Rails::TestTask.new(libs: 'test:prepare') do |t|
+    t.pattern = 'test/lib/**/*_test.rb'
+  end
 end

--- a/test/coverage_helper.rb
+++ b/test/coverage_helper.rb
@@ -1,0 +1,24 @@
+class SimpleCov::Formatter::MergedFormatter
+  def format(result)
+    SimpleCov::Formatter::HTMLFormatter.new.format(result)
+    CodeClimate::TestReporter::Formatter.new.format(result)
+  end
+end
+
+if ENV['CODECLIMATE_REPO_TOKEN']
+  CodeClimate::TestReporter.start
+  SimpleCov.formatter = SimpleCov::Formatter::MergedFormatter
+else
+  SimpleCov.start do
+    add_filter '/test/'
+    add_filter '/config/'
+    add_filter '/vendor/'
+
+    add_group 'Controllers', 'app/controllers'
+    add_group 'Models', 'app/models'
+    add_group 'Services', 'app/services'
+    add_group 'Serializers', 'app/serializers'
+    add_group 'Libs', 'lib/'
+  end
+  SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
+end

--- a/test/fixture_helper.rb
+++ b/test/fixture_helper.rb
@@ -1,4 +1,4 @@
-def read_fixture(name, erb=true)
+def read_fixture(name, erb = true)
   filename = File.realpath(File.join('./fixtures/', name), __dir__)
   content = open(filename).read
   erb ? ERB.new(content).result : content

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,45 +1,78 @@
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start
+ENV['RAILS_ENV'] = 'test'
 
-ENV["RAILS_ENV"] = "test"
+require 'codeclimate-test-reporter'
+require 'simplecov'
+
+class SimpleCov::Formatter::MergedFormatter
+  def format(result)
+    SimpleCov::Formatter::HTMLFormatter.new.format(result)
+    CodeClimate::TestReporter::Formatter.new.format(result)
+ end
+end
+
+if ENV['CODECLIMATE_REPO_TOKEN']
+  CodeClimate::TestReporter.start
+  SimpleCov.formatter = SimpleCov::Formatter::MergedFormatter
+else
+  SimpleCov.start do
+    add_filter '/test/'
+    add_filter '/config/'
+    add_filter '/vendor/'
+
+    add_group 'Controllers', 'app/controllers'
+    add_group 'Models', 'app/models'
+    add_group 'Services', 'app/services'
+    add_group 'Serializers', 'app/serializers'
+    add_group 'Libs', 'lib/'
+  end
+  SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
+end
 
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 require 'minitest/rails'
+require 'webmock_helper'
+require 'mocha/mini_test'
+
+require_dependency 'auth/current_user_provider'
 
 require 'sidekiq/testing'
 Sidekiq::Testing.inline!
-
-require 'webmock/minitest'
-require 'webmock_helper'
-
-require 'mocha/mini_test'
 
 require 'json_expressions/minitest'
 JsonExpressions::Matcher.assume_strict_arrays = false
 JsonExpressions::Matcher.assume_strict_hashes = false
 
+require 'webmock/minitest'
+WebMock.disable_net_connect!(allow: %w(codeclimate.com robohash.org))
 $redis = ConnectionPool.new { MockRedis.new }
 
-class ActiveSupport::TestCase
-  fixtures :all
-  include FactoryGirl::Syntax::Methods
+module ActiveSupport
+  class TestCase
+    include FactoryGirl::Syntax::Methods
+
+    fixtures :all
+  end
 end
 
-require_dependency 'auth/current_user_provider'
+module ActionController
+  class TestCase
+    include Devise::TestHelpers
 
-class ActionController::TestCase
-  include Devise::TestHelpers
+    def sign_in(user)
+      @controller.env['_CURRENT_USER'] = user
+    end
 
-  def sign_in(user)
-    @controller.env["_CURRENT_USER"] = user
-  end
+    def assert_preloaded(key)
+      json = JSON.parse(assigns['preload'].to_json)
+             .map(&:keys)
+             .flatten
+             .include?(key)
+      assert json, "#{key} should be preloaded"
+    end
 
-  def assert_preloaded(key)
-    assert JSON.parse(assigns["preload"].to_json).map {|x| x.keys }.flatten.include?(key), "#{key} should be preloaded"
-  end
-
-  def assert_json_body(matcher)
-    assert_json_match(matcher, @response.body)
+    def assert_json_body(matcher)
+      assert_json_match(matcher, @response.body)
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,33 +1,7 @@
 ENV['RAILS_ENV'] = 'test'
 
 require 'codeclimate-test-reporter'
-require 'simplecov'
-
-class SimpleCov::Formatter::MergedFormatter
-  def format(result)
-    SimpleCov::Formatter::HTMLFormatter.new.format(result)
-    CodeClimate::TestReporter::Formatter.new.format(result)
- end
-end
-
-if ENV['CODECLIMATE_REPO_TOKEN']
-  CodeClimate::TestReporter.start
-  SimpleCov.formatter = SimpleCov::Formatter::MergedFormatter
-else
-  SimpleCov.start do
-    add_filter '/test/'
-    add_filter '/config/'
-    add_filter '/vendor/'
-
-    add_group 'Controllers', 'app/controllers'
-    add_group 'Models', 'app/models'
-    add_group 'Services', 'app/services'
-    add_group 'Serializers', 'app/serializers'
-    add_group 'Libs', 'lib/'
-  end
-  SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
-end
-
+require 'coverage_helper' # Need to be called before Rails
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 require 'minitest/rails'

--- a/test/webmock_helper.rb
+++ b/test/webmock_helper.rb
@@ -1,18 +1,19 @@
-WebMock.disable_net_connect!(allow: %w[codeclimate.com robohash.org])
-
-class ActiveSupport::TestCase
-  def fake_requests(routes)
-    routes.map { |k, v|
-      # Ghetto globbing
-      if k[1].is_a?(String)
-        k[1].gsub!("*", "[^/]*")
-        k[1] = Regexp.new("^#{k[1]}$")
+module ActiveSupport
+  class TestCase
+    def fake_requests(routes)
+      routes_mapped = routes.map do |k, v|
+        # Ghetto globbing
+        if k[1].is_a? String
+          k[1].gsub!('*', '[^/]*')
+          k[1] = Regexp.new("^#{k[1]}$")
+        end
+        [k, v]
       end
-      [k, v]
-    }.each do |url, filename|
-      file = File.open(File.join("test", "fixtures", "webmock", "#{filename}.response"))
-      stub_request(url[0], url[1]).to_return(file)
+      routes_mapped.each do |url, filename|
+        file = File.open("test/fixtures/webmock/#{filename}.response")
+        stub_request(url[0], url[1]).to_return(file)
+      end
     end
+    alias_method :fake_request, :fake_requests
   end
-  alias_method :fake_request, :fake_requests
 end


### PR DESCRIPTION
That messy output that was generated when running tests was getting on my nerve, so I refactored it. I also added support to Rconv, so we can check code coverage data that is generated on the `/coverage` folder