### PR TITLE
fix image link for pro-banner on users page

### DIFF
--- a/frontend/app/templates/user.hbs
+++ b/frontend/app/templates/user.hbs
@@ -106,7 +106,7 @@
 <div class="container">
   <div class="feed-head-advert">
     <div class="ad-background">
-      {{#link-to 'pro'}}<img src="../assets/pro-banner.jpg">{{/link-to}}
+      {{#link-to 'pro'}}<img src="/assets/pro-banner.jpg">{{/link-to}}
     </div>
     {{ad-unit adId="1293413" adClass="257f81e798bd68dd81e60f42838f361f"}}
   </div>


### PR DESCRIPTION
:speech_balloon: :arrow_up:

Relative made it so on pages such as `/library` broke the banner link.