### PR TITLE
Enhance quickupdate when viewing on half of a 1080p screen

### DIFF
--- a/app/assets/stylesheets/components/quick-update.css.scss
+++ b/app/assets/stylesheets/components/quick-update.css.scss
@@ -126,7 +126,7 @@
   }
 
   @media (max-width: 959px) {
-    overflow: scroll;
+    overflow: auto;
 
     .series-slider {
       width: 870px;

--- a/app/assets/stylesheets/components/quick-update.css.scss
+++ b/app/assets/stylesheets/components/quick-update.css.scss
@@ -132,10 +132,8 @@
       width: 870px;
     }
     .watched-series {
-      max-width: 170px;
-    }
-    .update-arrow {
-      display: none;
+      max-width: 134px;
+      min-width: 134px;
     }
     .seen-text {
       display: none;


### PR DESCRIPTION
Some css changes that allow people viewing the site on half of a 1080p screen to see and use the arrows (most handy!) on the quick update view. It also disables the scrollbars when they are not needed instead of greying them out.