### PR TITLE
Fix eager loading not using left outer join

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -76,7 +76,7 @@ class Story < ActiveRecord::Base
   end
 
   def self.for_user(user)
-    query = eager_load(:library_entry)
+    query = joins("LEFT OUTER JOIN library_entries ON library_entries.id = stories.library_entry_id")
             .where("library_entries.id IS NULL OR library_entries.private = 'f'")
     query = query.where.not(adult: true) if user.nil? || user.sfw_filter
     query


### PR DESCRIPTION
`eager_loading` and `joins` can't create a `LEFT OUTER JOIN`, so it brings more data than we need, getting some problems like #617. This PR fixes it.