### PR TITLE
Try removing XMLCleaner

### DIFF
--- a/app/controllers/settings/import_controller.rb
+++ b/app/controllers/settings/import_controller.rb
@@ -20,7 +20,7 @@ class Settings::ImportController < ApplicationController
     else
       return error!(400, 'Unknown format')
     end
-    xml = XMLCleaner.clean(xml)
+    xml.scrub!
 
     return error!(422, 'Blank file') if xml.blank?
 


### PR DESCRIPTION
Replace with `String#scrub`

This might backfire, but currently there's an `xmllint` issue with `EPIPE` where xmllint appears to be closing its pipe early.  It seems like it's worth a try, now that we have at least _some_ error handling.