### PR TITLE
Fix synopsis remover in importer

### DIFF
--- a/lib/mal_import.rb
+++ b/lib/mal_import.rb
@@ -103,7 +103,7 @@ class MALImport
       }.compact,
       synopsis: begin
         synopsis = @main_noko.css('td td:contains("Synopsis")')[0].text.gsub("EditSynopsis", '').split("EditBackground")[0].split("googletag.cmd.push")[0]
-        if synopsis.include? "No synopsis has been added"
+        if synopsis.include? "No synopsis"
           nil
         else
           synopsis


### PR DESCRIPTION
MAL updated their "No synopsis" message again.

Ex.
https://hummingbird.me/manga/koi-wa-ameagari-no-you-ni
https://hummingbird.me/manga/youkoso-jitsuryoku-shijou-shugi-no-kyoushitsu-e