### PR TITLE
Update Headers

### DIFF
--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -12,12 +12,12 @@
           / Left Nav Section
           %ul.left.topnav-links
             %li.has-dropdown
-              = link_to "Dashboard", user_signed_in? ? "/" : "/sign-in"
+              = link_to "Library", "#"
               %ul.dropdown.rounded-panel
                 %li
-                  = link_to "Profile", user_signed_in? ? main_app.user_path(current_user) : "/sign-in"
+                  = link_to "Anime Library", user_signed_in? ? main_app.user_library_path(current_user) : "/sign-in"
                 %li
-                  = link_to "Library", user_signed_in? ? main_app.user_library_path(current_user) : "/sign-in"
+                  = link_to "Manga Library", user_signed_in? ? "/users/#{current_user.name}/library/manga" : "/sign-in"
                 %li
                   = link_to "Recommendations", '/recommendations'
             %li.has-dropdown
@@ -56,7 +56,9 @@
                 = link_to image_tag(current_user.avatar_url, :class => "avatar"), main_app.user_path(current_user), :class => "avatar-link-selector"
                 %ul.dropdown.rounded-panel
                   %li
-                    = link_to "Edit profile", main_app.edit_user_registration_path
+                    = link_to "View Profile", main_app.user_path(current_user)
+                  %li
+                    = link_to "Settings", main_app.edit_user_registration_path
                   - if current_user.admin?
                     %li 
                       = link_to "Admin panel", "/kotodama"

--- a/frontend/app/templates/header.hbs
+++ b/frontend/app/templates/header.hbs
@@ -16,11 +16,10 @@
       {{#if currentUser.isSignedIn}}
         <li class='dropdown'>
           <a class='dropdown-toggle' data-toggle='dropdown'>
-            Dashboard <b class='caret'></b>
+            Library <b class='caret'></b>
           </a>
           <!-- <i class='dropdown-arrow dropdown-arrow-inverse'></i> -->
           <ul class='dropdown-menu left-nav-section'>
-            <li>{{#link-to 'user.index' currentUser.id}}Profile{{/link-to}}</li>
             <li>{{#link-to 'user.library' currentUser.id}}Anime Library{{/link-to}}</li>
             <li>{{#link-to 'user.manga_library' currentUser.id}}Manga Library{{/link-to}}</li>
             <li><a href='/recommendations'>Recommendations</a></li>


### PR DESCRIPTION
_Fixes issue mentioned in #624_ and also fixes/improves some other things I noticed.

To sum up the changes:

* Removed "Profile" links from the Dashboard dropdown, as it becomes unnecessary when there already is "View Profile" in the profile dropdown. (both headers)
* Renamed Dashboard to Library as it is only holding links to the libraries and recommendations and the Dashboard is generally accessible over the navbar brand. (both headers)
* Removed the link from the Dashboard dropdown in the old header design to unify it with the new header, as dropdown links in Bootstrap can't open another page while being clicked. (basically just links to `#`)
* Added Manga library link (old header)
* Added "View Profile" and renamed "Edit Profile" to "Settings" in profile dropdown (old header)

As the old header is going to be dropped at some point these changes are just temporary solutions until everything is switched over to the new design and implemented.