### PR TITLE
fix quick-update pagination being enabled with 0 entries on next page

### DIFF
--- a/frontend/app/components/quick-update.js
+++ b/frontend/app/components/quick-update.js
@@ -7,7 +7,7 @@ export default Ember.Component.extend({
   libraryEntries: [],
   canGoBack: Ember.computed.gt('page', 1),
   canGoForward: function() {
-    return !this.get('loading') && this.get('libraryEntries.length') === 6;
+    return !this.get('loading') && this.get('libraryEntries.length') === 6 && !this.fetchPage(this.get('page') + 1).get('libraryEntries.length') === 0;
   }.property('loading', 'libraryEntries.length'),
 
   fetchPage: function(page) {


### PR DESCRIPTION
_this is pretty much just an attempted fix (as I can't test locally right now) for one of the issues mentioned in #152_

if the line is too long I can move parts of it into a new function, but I'd like to know if the code itself works first, so I need someone to take a quick glimpse at it.