### PR TITLE
Fix importing of genres and ratings for anime

### DIFF
--- a/lib/mal_import.rb
+++ b/lib/mal_import.rb
@@ -111,7 +111,6 @@ class MALImport
       rescue
       end,
       poster_image: poster_image(@sidebar.css("img")[0]['src']),
-      genres: begin (@sidebar.css('span:contains("Genres:") ~ a').map(&:text) rescue []).compact end,
       type: begin allowed_types.grep(@sidebar.css('div:contains("Type:")')[0].text.gsub("Type:", '').strip)[0] rescue nil end,
       status: begin @sidebar.css('div:contains("Status:")')[0].children[1].text.strip.gsub(/\w+/){ |w| w.capitalize } rescue nil end
     }
@@ -124,9 +123,10 @@ class MALImport
         volume_count: begin @sidebar.css('div:contains("Volumes:")')[0].text.gsub("Volumes: ", "").strip.to_i rescue nil end,
         chapter_count: begin @sidebar.css('div:contains("Chapters:")')[0].text.gsub("Chapters: ", "").strip.to_i rescue nil end,
         serialization: begin @sidebar.css('span:contains("Serialization:") ~ a').map(&:text)[0] rescue nil end,
+        genres: begin (@sidebar.css('span:contains("Genres:") ~ a').map(&:text) rescue []).compact end,
       })
     when :anime
-      age_rating = begin @sidebar.css('div:contains("Rating:")')[0].children[1].text.strip rescue nil end
+      age_rating = begin @sidebar.css('div:contains("Rating:")')[0].text.gsub("Rating:\n ", "").strip rescue nil end
       age_rating = convert_age_rating(age_rating)
       meta.merge!({
         dates: begin @sidebar.css('div:contains("Aired:")')[0].text.gsub("Aired:", '').split("to").map { |s| parse_maldate(s) } rescue nil end,
@@ -135,6 +135,7 @@ class MALImport
         age_rating_guide: age_rating[1],
         episode_count: begin @sidebar.css('div:contains("Episodes:")')[0].children[1].text.strip.to_i rescue nil end,
         episode_length: parse_duration(begin @sidebar.css('div:contains("Duration:")')[0].children[1].text.strip rescue nil end),
+        genres: begin (@sidebar.css('span:contains("Genres:") ~ span a').map(&:text) rescue []).compact end,
       })
     end
 

--- a/lib/mal_import.rb
+++ b/lib/mal_import.rb
@@ -133,8 +133,8 @@ class MALImport
         producers: begin (@sidebar.css('span:contains("Producers:") ~ a').map(&:text) rescue []).compact end,
         age_rating: age_rating[0],
         age_rating_guide: age_rating[1],
-        episode_count: begin @sidebar.css('div:contains("Episodes:")')[0].children[1].text.strip.to_i rescue nil end,
-        episode_length: parse_duration(begin @sidebar.css('div:contains("Duration:")')[0].children[1].text.strip rescue nil end),
+        episode_count: begin @sidebar.css('div:contains("Episodes:")')[0].text.gsub("Episodes: ", "").strip.to_i rescue nil end,
+        episode_length: parse_duration(begin @sidebar.css('div:contains("Duration:")')[0].text.gsub("Duration: ", "").strip rescue nil end),
         genres: begin (@sidebar.css('span:contains("Genres:") ~ span a').map(&:text) rescue []).compact end,
       })
     end


### PR DESCRIPTION
It looks like there was a slight change in the structure of anime pages on MAL which broke some things.
Ex. https://hummingbird.me/anime/pokemon-xy-z