### PR TITLE
Add ElasticSearch to the docker stack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,6 @@ RUN bash -c "source /usr/local/rvm/scripts/rvm && \
     gem install foreman"
 
 COPY . /opt/hummingbird
-COPY github_key /root/.ssh/id_rsa
-RUN chmod 0600 /root/.ssh/id_rsa
 
 EXPOSE 3000
 ENTRYPOINT ["/opt/hummingbird/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ postgres:
     POSTGRES_USER: postgres
 redis:
   image: redis
+elasticsearch:
+  image: elasticsearch
 web:
   build: .
   volumes:
@@ -16,6 +18,7 @@ web:
   links:
     - postgres
     - redis
+    - elasticsearch
   environment:
     RAILS_ENV: development
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,9 @@ source ${root_path}/server/.env
 export REDIS_HOST=${REDIS_PORT_6379_TCP_ADDR}
 export REDIS_URL=redis://${REDIS_PORT_6379_TCP_ADDR}:${REDIS_PORT_6379_TCP_PORT}/0
 
+export ELASTICSEARCH_HOST=${ELASTICSEARCH_PORT_9200_TCP_ADDR}
+export ELASTICSEARCH_PORT=${ELASTICSEARCH_PORT_9200_TCP_PORT}
+
 [ -e /usr/local/rvm/scripts/rvm  ] && \
     source /usr/local/rvm/scripts/rvm
 

--- a/server/.env
+++ b/server/.env
@@ -3,6 +3,9 @@ RAILS_ENV=development
 REDIS_HOST=localhost
 REDIS_URL=redis://localhost:6379/0
 
+ELASTICSEARCH_HOST=localhost
+ELASTICSEARCH_PORT=9200
+
 # Limited privileges, don't bother trying. ;)
 AWS_BUCKET=hummingbird-me
 AWS_ACCESS_KEY_ID=AKIAIEMWFZV65HLXMY7Q


### PR DESCRIPTION
`ELASTICSEARCH_HOST` and `ELASTICSEARCH_PORT` are exposed to be used in the application to contact elasticsearch.