### PR TITLE
server: Only allow current user to create entries

### DIFF
--- a/server/app/resources/library_entry_resource.rb
+++ b/server/app/resources/library_entry_resource.rb
@@ -10,4 +10,14 @@ class LibraryEntryResource < BaseResource
   has_one :anime
 
   paginator :unlimited
+
+  after_replace_fields :correct_user?
+
+  private
+
+  def correct_user?
+    is_user_or_admin = @model.user == current_user ||
+                       current_user.has_role?(:admin, LibraryEntry)
+    not_authorized! :create? unless is_new? && is_user_or_admin
+  end
 end

--- a/server/spec/policies/library_entry_policy_spec.rb
+++ b/server/spec/policies/library_entry_policy_spec.rb
@@ -38,7 +38,12 @@ RSpec.describe LibraryEntryPolicy do
     end
   end
 
-  permissions :create?, :update?, :destroy? do
+  permissions :create? do
+    it ('should allow user') { should permit(owner, entry) }
+    it ('should not allow anon') { should_not permit(nil, entry) }
+  end
+
+  permissions :update?, :destroy? do
     it ('should allow owner') { should permit(owner, entry) }
     it ('should allow admin') { should permit(admin, entry) }
     it ('should not allow random dude') { should_not permit(user, entry) }


### PR DESCRIPTION
* This allows for extra logic at the resource level while the policy is still
  correct in that "any" logged in user can create a library entry.
* This uses `after_replace_fields` from JR, and checks JR's internal function
  `#is_new?` to determine if this is a new record (AKA create request).

@NuckChorris thoughts?