### PR TITLE
Robustificate MAL imports

### DIFF
--- a/lib/my_anime_list_import.rb
+++ b/lib/my_anime_list_import.rb
@@ -45,7 +45,8 @@ class MyAnimeListImport
     if @data.nil?
       @data = []
 
-      @data = hashdata[list].map do |indv|
+      # wrap+flatten+compact to ensure we get an array with no nils
+      @data = [hashdata[list]].flatten.compact.map do |indv|
         row = {
           rating: indv["my_score"].to_i,
           notes: indv["my_comments"].blank? ? indv["my_tags"] : indv["my_comments"]


### PR DESCRIPTION
So this is solving a few different problems with MAL imports:

1. Anime titles which have ampersands ("Panty & Stocking with Garterbelt" for example) are apparently sometimes not escaped by MAL exports.  This is fixed using a `gsub` to escape them.
2. Lists without any entries would result in an "Invalid list type" error in the sidekiq worker.  This is fixed by detecting that case in the controller.
3. Users could upload random non-MAL XML files and it would break in the sidekiq worker.  This is fixed by checking for `<myanimelist>` in the XML, which should sniff out all but the weirdest cases.

In all of these cases, the error message will now be passed back to the user to remedy.