### PR TITLE
Merge LibraryEntry and MangaLibraryEntry

### DIFF
--- a/server/app/models/anime.rb
+++ b/server/app/models/anime.rb
@@ -38,13 +38,13 @@
 #
 
 class Anime < ActiveRecord::Base
+  DEFAULT_PROGRESS_LIMIT = 400
   SEASONS = %w[winter spring summer fall]
 
   include Media
   include AgeRatings
   include Episodic
 
-  has_many :library_entries, dependent: :destroy
   has_many :streaming_links, as: 'media', dependent: :destroy
 
   update_index('media#anime') { self }

--- a/server/app/models/concerns/episodic.rb
+++ b/server/app/models/concerns/episodic.rb
@@ -13,5 +13,6 @@ module Episodic
   included do
     has_many :episodes, as: 'media', dependent: :destroy
     has_many :streaming_links, as: 'media', dependent: :destroy
+    alias_attribute :progress_limit, :episode_count
   end
 end

--- a/server/app/models/concerns/media.rb
+++ b/server/app/models/concerns/media.rb
@@ -6,6 +6,7 @@ module Media
     include Titleable
     include Rateable
 
+    has_many :library_entries, as: 'media', dependent: :destroy
     friendly_id :slug_candidates, use: %i[slugged finders history]
     resourcify
 

--- a/server/app/models/concerns/rateable.rb
+++ b/server/app/models/concerns/rateable.rb
@@ -9,9 +9,8 @@ module Rateable
   end
 
   def recalculate_rating_frequencies!
-    frequencies = LibraryEntry::VALID_RATINGS.map do |rating|
-      [rating, LibraryEntry.where(anime: self, rating: rating).count]
-    end
-    self.rating_frequencies = Hash[frequencies]
+    frequencies = LibraryEntry.where(media: self).group(:rating).count.
+      transform_keys(&:to_f)
+    self.rating_frequencies = frequencies.slice(LibraryEntry::VALID_RATINGS)
   end
 end

--- a/server/app/models/manga.rb
+++ b/server/app/models/manga.rb
@@ -32,10 +32,13 @@
 #
 
 class Manga < ActiveRecord::Base
+  DEFAULT_PROGRESS_LIMIT = 1000
+
   include Media
 
   enum manga_type: %i[manga novel manhua oneshot doujin]
   enum status: %i[not_published publishing finished]
+  alias_attribute :progress_limit, :chapter_count
 
   def slug_candidates
     [

--- a/server/app/policies/library_entry_policy.rb
+++ b/server/app/policies/library_entry_policy.rb
@@ -5,7 +5,7 @@ class LibraryEntryPolicy < ApplicationPolicy
     # No, if it's private
     return false if record.private?
     # No, if it's nsfw and you're not a perv
-    return false if user.sfw_filter? && record.anime.nsfw?
+    return false if user.sfw_filter? && record.media.nsfw?
     # Otherwise, yeah
     true
   end

--- a/server/app/resources/library_entry_resource.rb
+++ b/server/app/resources/library_entry_resource.rb
@@ -1,13 +1,13 @@
 require 'unlimited_paginator'
 
 class LibraryEntryResource < BaseResource
-  attributes :status, :episodes_watched, :rewatching, :rewatch_count,
-             :notes, :private, :rating, :updated_at
+  attributes :status, :progress, :reconsuming, :reconsume_count, :notes,
+             :private, :rating, :updated_at
 
-  filters :user_id, :anime_id, :status
+  filters :user_id, :media_id, :media_type, :status
 
   has_one :user
-  has_one :anime
+  has_one :media, polymorphic: true
 
   paginator :unlimited
 end

--- a/server/db/migrate/20151211081155_merge_manga_and_library_entries.rb
+++ b/server/db/migrate/20151211081155_merge_manga_and_library_entries.rb
@@ -1,0 +1,79 @@
+class MergeMangaAndLibraryEntries < ActiveRecord::Migration
+  def change
+    # Anime --> Media
+    remove_index :library_entries, [:user_id, :anime_id]
+    rename_column :library_entries, :anime_id, :media_id
+    add_column :library_entries, :media_type, :string
+    change_column_null :library_entries, :media_type, false, 'Anime'
+    add_index :library_entries, [:user_id, :media_type, :media_id], unique: true
+
+    # Episodes --> Progress
+    rename_column :library_entries, :episodes_watched, :progress
+
+    # Rewatch --> Reconsume
+    rename_column :library_entries, :rewatching, :reconsuming
+    rename_column :library_entries, :rewatch_count, :reconsume_count
+
+    # Add volumes column
+    add_column :library_entries, :volumes_owned, :integer, default: 0, null: false
+
+    # General cleanup
+    change_column_null :library_entries, :private, false, false
+    change_column_null :library_entries, :status, false
+    change_column_null :library_entries, :media_id, false
+    change_column_null :library_entries, :media_type, false
+    change_column_null :library_entries, :user_id, false
+
+    # Convert manga to integer status
+    change_column :manga_library_entries, :status, "integer USING (
+      CASE status
+      WHEN 'Currently Reading' THEN 1
+      WHEN 'Plan to Read' THEN 2
+      WHEN 'Completed' THEN 3
+      WHEN 'On Hold' THEN 4
+      WHEN 'Dropped' THEN 5
+      ELSE 1
+      END
+    )".squish
+
+    # Remove duplicates on (user_id, manga_id), picking the higher updated_at
+    # The new destination table has a uniqueness constraint to prevent this in
+    # future, but we still have some dupes we need to fix.
+    execute <<-SQL.squish
+      DELETE FROM manga_library_entries
+      WHERE id IN (
+        SELECT id FROM (
+          SELECT id, ROW_NUMBER()
+          OVER (partition BY user_id, manga_id ORDER BY updated_at DESC) AS rnum
+          FROM manga_library_entries
+        ) t
+        WHERE t.rnum > 1
+      )
+    SQL
+
+    # Now we shuffle manga library entries into here!
+    execute <<-SQL.squish
+      INSERT INTO library_entries (
+        user_id, media_id, media_type, progress, status, volumes_owned,
+        reconsume_count, reconsuming, private, rating, created_at, updated_at,
+        notes)
+      SELECT user_id,
+             manga_id AS media_id,
+             'Manga' AS media_type,
+             chapters_read AS progress,
+             status AS status,
+             volumes_read AS volumes_owned,
+             reread_count AS reconsume_count,
+             rereading AS reconsuming,
+             private,
+             rating,
+             created_at,
+             coalesce(updated_at, created_at, now()),
+             notes
+      FROM manga_library_entries
+    SQL
+
+    # And finally remove the manga library entries table
+    drop_table :manga_library_entries
+  end
+end

--- a/server/db/schema.rb
+++ b/server/db/schema.rb
@@ -292,20 +292,22 @@ ActiveRecord::Schema.define(version: 20160109045957) do
   add_index "installments", ["media_type", "media_id"], name: "index_installments_on_media_type_and_media_id", unique: true, using: :btree
 
   create_table "library_entries", force: :cascade do |t|
-    t.integer  "user_id"
-    t.integer  "anime_id"
-    t.integer  "status"
-    t.datetime "created_at",                                               null: false
-    t.datetime "updated_at",                                               null: false
-    t.integer  "episodes_watched",                         default: 0,     null: false
-    t.decimal  "rating",           precision: 2, scale: 1
-    t.boolean  "private",                                  default: false
+    t.integer  "user_id",                                                 null: false
+    t.integer  "media_id",                                                null: false
+    t.integer  "status",                                                  null: false
+    t.datetime "created_at",                                              null: false
+    t.datetime "updated_at",                                              null: false
+    t.integer  "progress",                                default: 0,     null: false
+    t.decimal  "rating",          precision: 2, scale: 1
+    t.boolean  "private",                                 default: false, null: false
     t.text     "notes"
-    t.integer  "rewatch_count",                            default: 0,     null: false
-    t.boolean  "rewatching",                               default: false, null: false
+    t.integer  "reconsume_count",                         default: 0,     null: false
+    t.boolean  "reconsuming",                             default: false, null: false
+    t.string   "media_type",                                              null: false
+    t.integer  "volumes_owned",                           default: 0,     null: false
   end
 
-  add_index "library_entries", ["user_id", "anime_id"], name: "index_library_entries_on_user_id_and_anime_id", unique: true, using: :btree
+  add_index "library_entries", ["user_id", "media_type", "media_id"], name: "index_library_entries_on_user_id_and_media_type_and_media_id", unique: true, using: :btree
   add_index "library_entries", ["user_id", "status"], name: "index_library_entries_on_user_id_and_status", using: :btree
   add_index "library_entries", ["user_id"], name: "index_library_entries_on_user_id", using: :btree
 
@@ -337,26 +339,6 @@ ActiveRecord::Schema.define(version: 20160109045957) do
     t.string   "canonical_title",                       default: "ja_en", null: false
     t.string   "abbreviated_titles",                                                   array: true
   end
-
-  create_table "manga_library_entries", force: :cascade do |t|
-    t.integer  "user_id",                                                           null: false
-    t.integer  "manga_id",                                                          null: false
-    t.string   "status",        limit: 255,                                         null: false
-    t.boolean  "private",                                           default: false, null: false
-    t.integer  "chapters_read",                                     default: 0,     null: false
-    t.integer  "volumes_read",                                      default: 0,     null: false
-    t.integer  "reread_count",                                      default: 0,     null: false
-    t.boolean  "rereading",                                         default: false, null: false
-    t.datetime "last_read"
-    t.decimal  "rating",                    precision: 2, scale: 1
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.text     "notes"
-    t.boolean  "imported",                                          default: false, null: false
-  end
-
-  add_index "manga_library_entries", ["manga_id"], name: "index_manga_library_entries_on_manga_id", using: :btree
-  add_index "manga_library_entries", ["user_id"], name: "index_manga_library_entries_on_user_id", using: :btree
 
   create_table "not_interesteds", force: :cascade do |t|
     t.integer  "user_id"

--- a/server/spec/controllers/library_entries_controller_spec.rb
+++ b/server/spec/controllers/library_entries_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe LibraryEntriesController, type: :controller do
-  LIBRARY_ENTRY ||= { status: String, episodesWatched: Fixnum }
+  LIBRARY_ENTRY ||= { status: String, progress: Fixnum }
   let(:user) { create(:user) }
   let(:anime) { create(:anime) }
 
@@ -14,19 +14,20 @@ RSpec.describe LibraryEntriesController, type: :controller do
       end
     end
 
-    describe 'with filter[anime_id]' do
+    describe 'with filter[media_type] + filter[media_id]' do
       it 'should respond with a list of library entries' do
-        5.times { create(:library_entry, anime: anime) }
-        get :index, filter: { anime_id: anime.id }
+        5.times { create(:library_entry, media: anime) }
+        get :index, filter: { media_id: anime.id, media_type: 'Anime' }
         expect(response.body).to have_resources(LIBRARY_ENTRY, 'libraryEntries')
       end
     end
 
-    describe 'with filter[user_id] and filter[anime_id]' do
+    describe 'with filter[user_id] + filter[media_type] + filter[media_id]' do
       it 'should respond with a single library entry as an array' do
-        create(:library_entry, user: user, anime: anime)
-        5.times { create(:library_entry, user: build(:user), anime: anime) }
-        get :index, filter: { anime_id: anime.id, user_id: user }
+        create(:library_entry, user: user, media: anime)
+        5.times { create(:library_entry, user: build(:user), media: anime) }
+        get :index, filter: { media_id: anime.id, media_type: 'Anime',
+                              user_id: user }
         expect(response.body).to have_resources(LIBRARY_ENTRY, 'libraryEntries')
         expect(JSON.parse(response.body)['data'].count).to equal(1)
       end
@@ -35,8 +36,9 @@ RSpec.describe LibraryEntriesController, type: :controller do
     describe 'with logged in user' do
       it "should respond with a single private library entry as an array" do
         sign_in(user)
-        create(:library_entry, user: user, anime: anime, private: true)
-        5.times { create(:library_entry, user: build(:user), anime: anime, private:true) }
+        create(:library_entry, user: user, media: anime, private: true)
+        5.times { create(:library_entry, user: build(:user), media: anime,
+                                         private: true) }
         get :index
         expect(response.body).to have_resources(LIBRARY_ENTRY, 'libraryEntries')
         expect(JSON.parse(response.body)['data'].count).to equal(1)
@@ -44,8 +46,8 @@ RSpec.describe LibraryEntriesController, type: :controller do
 
       it "should respond with a list of library entries" do
         sign_in(user)
-        create(:library_entry, user: user, anime: anime, private: true)
-        5.times { create(:library_entry, user: build(:user), anime: anime) }
+        create(:library_entry, user: user, media: anime, private: true)
+        5.times { create(:library_entry, user: build(:user), media: anime) }
         get :index
         expect(response.body).to have_resources(LIBRARY_ENTRY, 'libraryEntries')
         expect(JSON.parse(response.body)['data'].count).to equal(6)

--- a/server/spec/factories/library_entries.rb
+++ b/server/spec/factories/library_entries.rb
@@ -2,28 +2,30 @@
 #
 # Table name: library_entries
 #
-#  id               :integer          not null, primary key
-#  user_id          :integer
-#  anime_id         :integer
-#  status           :integer
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  episodes_watched :integer          default(0), not null
-#  rating           :decimal(2, 1)
-#  private          :boolean          default(FALSE)
-#  notes            :text
-#  rewatch_count    :integer          default(0), not null
-#  rewatching       :boolean          default(FALSE), not null
+#  id              :integer          not null, primary key
+#  user_id         :integer          not null
+#  media_id        :integer          not null
+#  status          :integer          not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  progress        :integer          default(0), not null
+#  rating          :decimal(2, 1)
+#  private         :boolean          default(FALSE), not null
+#  notes           :text
+#  reconsume_count :integer          default(0), not null
+#  reconsuming     :boolean          default(FALSE), not null
+#  media_type      :string           not null
+#  volumes_owned   :integer          default(0), not null
 #
 
 FactoryGirl.define do
   factory :library_entry do
-    anime
+    association :media, factory: :anime
     user
     status 'planned'
 
     trait :nsfw do
-      association :anime, :nsfw
+      association :media, :nsfw, factory: :anime
     end
   end
 end

--- a/server/spec/models/library_entry_spec.rb
+++ b/server/spec/models/library_entry_spec.rb
@@ -2,46 +2,52 @@
 #
 # Table name: library_entries
 #
-#  id               :integer          not null, primary key
-#  user_id          :integer
-#  anime_id         :integer
-#  status           :integer
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  episodes_watched :integer          default(0), not null
-#  rating           :decimal(2, 1)
-#  private          :boolean          default(FALSE)
-#  notes            :text
-#  rewatch_count    :integer          default(0), not null
-#  rewatching       :boolean          default(FALSE), not null
+#  id              :integer          not null, primary key
+#  user_id         :integer          not null
+#  media_id        :integer          not null
+#  status          :integer          not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  progress        :integer          default(0), not null
+#  rating          :decimal(2, 1)
+#  private         :boolean          default(FALSE), not null
+#  notes           :text
+#  reconsume_count :integer          default(0), not null
+#  reconsuming     :boolean          default(FALSE), not null
+#  media_type      :string           not null
+#  volumes_owned   :integer          default(0), not null
 #
 
 require 'rails_helper'
 
 RSpec.describe LibraryEntry, type: :model do
+  let(:anime) { create(:anime, episode_count: 5) }
+  subject { build(:library_entry) }
+
   it { should validate_presence_of(:user) }
-  it { should validate_presence_of(:anime) }
+  it { should validate_presence_of(:media) }
   it { should validate_presence_of(:status) }
-  it { should validate_presence_of(:episodes_watched) }
-  it { should validate_presence_of(:rewatch_count) }
-  it { should validate_uniqueness_of(:user_id).scoped_to(:anime_id) }
+  it { should validate_presence_of(:progress) }
+  it { should validate_presence_of(:reconsume_count) }
+  it {
+    should validate_uniqueness_of(:user_id)
+      .scoped_to([:media_type, :media_id])
+  }
   it {
     should validate_numericality_of(:rating)
       .is_less_than_or_equal_to(5)
       .is_greater_than(0)
   }
 
-  describe 'episodes_watched_limit validation' do
-    it 'should fail when episodes_watched > episode_count' do
-      anime = create(:anime, episode_count: 5)
-      library_entry = build(:library_entry, anime: anime, episodes_watched: 6)
+  describe 'progress_limit validation' do
+    it 'should fail when progress > progress_limit' do
+      library_entry = build(:library_entry, media: anime, progress: 6)
       expect(library_entry).not_to be_valid
-      expect(library_entry.errors[:episodes_watched]).to be_present
+      expect(library_entry.errors[:progress]).to be_present
     end
-    it 'should pass when episodes_watched <= episode_count' do
-      anime = create(:anime, episode_count: 5)
-      library_entry = build(:library_entry, anime: anime, episodes_watched: 4)
-      expect(library_entry.errors[:episodes_watched]).to be_blank
+    it 'should pass when progress <= progress_limit' do
+      library_entry = build(:library_entry, media: anime, progress: 4)
+      expect(library_entry.errors[:progress]).to be_blank
     end
   end
 

--- a/server/spec/support/media_examples.rb
+++ b/server/spec/support/media_examples.rb
@@ -12,8 +12,10 @@ RSpec.shared_examples 'media' do
   it { should have_db_column(:end_date).of_type(:date) }
   it { should have_and_belong_to_many(:genres) }
   it { should have_many(:castings) }
+  it { should have_many(:library_entries) }
   # Methods used for the magic
   it { should respond_to(:slug_candidates) }
+  it { should respond_to(:progress_limit) }
   it { should delegate_method(:year).to(:start_date) }
   it {
     should validate_numericality_of(:average_rating)


### PR DESCRIPTION
With the whole addition of drama and the possibility of further changes to our library division, it seems reasonable to merge all libraries together so that any features will be implemented on all of them, and to make things like custom lists easier to implement.

This also has an interesting side benefit of making it easier to produce other sites based on the Hummingbird codebase (say, for VNs or non-Asian media)

There's some necessary changes to the JS due to the renaming of fields.