### PR TITLE
Fix character/person image import

### DIFF
--- a/lib/mal_import.rb
+++ b/lib/mal_import.rb
@@ -156,11 +156,11 @@ class MALImport
 
   private
   def character_image(img)
-    img = img.gsub("t.jpg", ".jpg")
+    img = img.gsub("r/21x32/", "").split("?s=")[0]
     URI(img) unless img.include?("questionmark")
   end
   def person_image(img)
-    img = img.gsub("v.jpg", ".jpg")
+    img = img.gsub("r/21x32/", "").split("?s=")[0]
     URI(img) unless img.include?("questionmark")
   end
   def poster_image(img)


### PR DESCRIPTION
The url scheme for character, cast and staff images has changed.

Ex.

 |Image|URL
---|---|---
Current|![](http://cdn.myanimelist.net/r/21x32/images/characters/2/301144.jpg?s=e35db62777b56c2cfd5c8664cf99f06c)|http://cdn.myanimelist.net/r/21x32/images/characters/2/301144.jpg?s=e35db62777b56c2cfd5c8664cf99f06c
Expected|![](http://cdn.myanimelist.net/images/characters/2/301144.jpg)|http://cdn.myanimelist.net/images/characters/2/301144.jpg