### PR TITLE
Show validation error messages on edits

### DIFF
--- a/app/controllers/full_anime_controller.rb
+++ b/app/controllers/full_anime_controller.rb
@@ -9,6 +9,7 @@ class FullAnimeController < ApplicationController
   def update
     anime = Anime.find(params[:id])
     version = anime.create_pending(current_user, full_anime_params)
+    return error!(version.item.errors.full_messages, 400) unless version.persisted?
     # if this user is admin, apply the changes
     # without review, but still create a history version
     anime.update_from_pending(version) if current_user.admin?

--- a/app/controllers/full_manga_controller.rb
+++ b/app/controllers/full_manga_controller.rb
@@ -7,6 +7,7 @@ class FullMangaController < ApplicationController
   def update
     manga = Manga.find(params[:id])
     version = manga.create_pending(current_user, full_manga_params)
+    return error!(version.item.errors.full_messages, 400) unless version.persisted?
     # if this user is admin, apply the changes
     # without review, but still create a history version
     manga.update_from_pending(version) if current_user.admin?

--- a/app/models/concerns/versionable.rb
+++ b/app/models/concerns/versionable.rb
@@ -7,6 +7,7 @@ module Versionable
     comment = object.delete(:edit_comment)
     # temp assign attributes
     self.assign_attributes(object)
+    # don't create the version if there was a validation error
     version = Version.new(
       item: self,
       user: author,
@@ -15,7 +16,7 @@ module Versionable
       comment: comment
     )
     version.state = :pending
-    version.save
+    version.save if self.errors.blank?
     version
   end
 


### PR DESCRIPTION
Currently a pending version is created even if there is validation errors. This hopefully puts an end to that.

A matter was brought up by @synthtech that Twitter image links have an odd file ending `:orig`/`:large`. This causes Paperclip to throw a validation error due to their content type spoof system. Seems we can support them by adding the content type mappings manually but unsure if its worth it due to V3 development.

/cc @NuckChorris 