### PR TITLE
Custom authorizer and create? policy for LibraryEntry

### DIFF
--- a/server/app/policies/library_entry_policy.rb
+++ b/server/app/policies/library_entry_policy.rb
@@ -1,7 +1,7 @@
 class LibraryEntryPolicy < ApplicationPolicy
   def show?
     # Yes, if you own it or are admin
-    return true if record.user == user || user.has_role?(:admin)
+    return true if record.user == user || is_admin?
     # No, if it's private
     return false if record.private?
     # No, if it's nsfw and you're not a perv
@@ -10,10 +10,13 @@ class LibraryEntryPolicy < ApplicationPolicy
     true
   end
 
+  def create?
+    !user.nil?
+  end
+
   def update?
     record.user == user || is_admin?
   end
-  alias_method :create?, :update?
   alias_method :destroy?, :update?
 
   class Scope < Scope

--- a/server/config/initializers/jsonapi-authorization.rb
+++ b/server/config/initializers/jsonapi-authorization.rb
@@ -1,3 +1,7 @@
 JSONAPI.configure do |config|
   config.operations_processor = :jsonapi_authorization
 end
+
+JSONAPI::Authorization.configure do |config|
+  config.authorizer = JSONAPI::Authorization::PunditAuthorizer
+end

--- a/server/lib/jsonapi/authorization/pundit_authorizer.rb
+++ b/server/lib/jsonapi/authorization/pundit_authorizer.rb
@@ -1,0 +1,14 @@
+# Create a new Authorizer for JSONAPI::Authorization that doesn't execute
+# `update?` on relationships when creating a new resource.
+#
+# This issue is currently in discussion @
+# https://github.com/venuu/jsonapi-authorization/issues/15
+module JSONAPI
+  module Authorization
+    class PunditAuthorizer < DefaultPunditAuthorizer
+      def create_resource(source_class, _related_records)
+        ::Pundit.authorize(user, source_class, 'create?')
+      end
+    end
+  end
+end

--- a/server/spec/policies/library_entry_policy_spec.rb
+++ b/server/spec/policies/library_entry_policy_spec.rb
@@ -41,7 +41,12 @@ RSpec.describe LibraryEntryPolicy do
   end
   # rubocop:enable Metrics/LineLength
 
-  permissions :create?, :update?, :destroy? do
+  permissions :create? do
+    it('should allow random dude') { should permit(user, entry) }
+    it('should not allow anon') { should_not permit(nil, entry) }
+  end
+
+  permissions :update?, :destroy? do
     it('should allow owner') { should permit(owner, entry) }
     it('should allow admin') { should permit(admin, entry) }
     it('should not allow random dude') { should_not permit(user, entry) }


### PR DESCRIPTION
Defines a `create?` policy for `LibraryEntry`, this is a needed change as before the switch to `jsonapi-authorizer` we were calling `create?` after the fields had been replaced.

-----

By default, `jsonapi-authorizer` calls `update?` on relationship objects when creating a resource. This fails for us in cases like creating a `LibraryEntry` where `AnimePolicy#update?` will always be false.

There is an active discussion about this upstream, so we may be able to get rid of this in the future.