### PR TITLE
Fix sql dump

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -1,5 +1,7 @@
 #!/bin/bash
 
 docker-compose build
-docker-compose run --rm server rake db:setup
+# Only create the database on development.
+# Schema and seed are bone by bin/seed
+docker-compose run --rm server rake db:create
 docker-compose run --rm server rake db:setup RAILS_ENV=test

--- a/bin/seed
+++ b/bin/seed
@@ -58,6 +58,9 @@ function do_import {
 }
 
 function do_import_db {
+  # Here we drop the schema manually instead db:drop because
+  # of other docker connections to the DB
+  echo "DROP SCHEMA public CASCADE;CREATE SCHEMA public;" | bin/psql "$DB_TARGET_ID"
   gzcat "$DB_FILE_NAME" | bin/psql "$DB_TARGET_ID"
   echo -e "${COLOR_GREEN}Imported $DB_FILE_NAME to $DB_TARGET_ID${COLOR_NONE}"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,13 +11,14 @@ volumes:
 services:
   # Database servers
   postgres:
-    image: postgres:9.3
+    image: postgres:9.4
     environment:
       PGDATA: /var/lib/postgresql/data/pgdata
       POSTGRES_PASSWORD: mysecretpassword
       POSTGRES_USER: postgres
     volumes:
       - postgres:/var/lib/postgresql/data
+    ports: ['5432:5432']
   redis:
     image: redis
   elasticsearch:


### PR DESCRIPTION
This PR fix #784, making the `bin/build` and `bin/seed` compatible with the structure that the seed dump works. It also update the Postgres version, preventing possible compatibility errors with future dumps