### PR TITLE
Fixed API url on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Kitsu is a modern anime discovery platform that helps you track the anime you're
 [client]:https://github.com/hummingbird-me/hummingbird-client
 [server]:https://github.com/hummingbird-me/hummingbird-server
 [mobile app]:https://github.com/hummingbird-me/kitsu-mobile
-[api docs]:https://github.com/hummingbird-me/hummingbird-client
+[api docs]:https://github.com/hummingbird-me/api-docs
 
 ---
 


### PR DESCRIPTION
Fixed the API url on README to point to the [API](https://github.com/hummingbird-me/api-docs) instead of the client.
Issue: #811 
