### PR TITLE
Fix Docker commands in scripts

### DIFF
--- a/bin/bower
+++ b/bin/bower
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker compose run --rm --entrypoint bower web $@
+docker-compose run --rm --entrypoint bower web $@

--- a/bin/build
+++ b/bin/build
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-docker compose build
+docker-compose build
 # Only create the database on development.
 # Schema and seed are done by bin/seed
-docker compose run --rm api rake db:create
-docker compose run --rm api rake db:setup RAILS_ENV=test
+docker-compose run --rm api rake db:create
+docker-compose run --rm api rake db:setup RAILS_ENV=test

--- a/bin/bundle
+++ b/bin/bundle
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker compose run --rm --entrypoint ./bin/bundle api $@
+docker-compose run --rm --entrypoint ./bin/bundle api $@

--- a/bin/clean-uploads
+++ b/bin/clean-uploads
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker compose run --rm --entrypoint rm api -rf "/opt/kitsu/server/public/system/*"
+docker-compose run --rm --entrypoint rm api -rf "/opt/kitsu/server/public/system/*"

--- a/bin/ember
+++ b/bin/ember
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker compose run --rm web $@
+docker-compose run --rm web $@

--- a/bin/guard
+++ b/bin/guard
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker compose run --rm -e "RAILS_ENV=test" api guard $@
+docker-compose run --rm -e "RAILS_ENV=test" api guard $@

--- a/bin/logs
+++ b/bin/logs
@@ -2,4 +2,4 @@
 
 containers="${@:-api web worker}"
 
-docker compose logs $containers
+docker-compose logs $containers

--- a/bin/npm
+++ b/bin/npm
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker compose run --rm --entrypoint npm web $@
+docker-compose run --rm --entrypoint npm web $@

--- a/bin/pg_dump
+++ b/bin/pg_dump
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker compose run --rm postgres sh -c "pg_dump --username=kitsu_development --host=postgres $@"
+docker-compose run --rm postgres sh -c "pg_dump --username=kitsu_development --host=postgres $@"

--- a/bin/port
+++ b/bin/port
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker compose port router 80 | cut -d: -f2
+docker-compose port router 80 | cut -d: -f2

--- a/bin/psql
+++ b/bin/psql
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker compose run --rm postgres sh -c "psql --username=kitsu_development --host=postgres $@"
+docker-compose run --rm postgres sh -c "psql --username=kitsu_development --host=postgres $@"

--- a/bin/rails
+++ b/bin/rails
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker compose run --rm --entrypoint ./bin/rails api $@
+docker-compose run --rm --entrypoint ./bin/rails api $@

--- a/bin/rake
+++ b/bin/rake
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker compose run --rm api rake $@
+docker-compose run --rm api rake $@

--- a/bin/rebuild
+++ b/bin/rebuild
@@ -4,7 +4,7 @@ cd "$(dirname "$0")/../"
 
 ./bin/check_for_updates
 
-docker compose stop $@
-docker compose rm -f $@
-docker compose build $@
-docker compose up -d $@
+docker-compose stop $@
+docker-compose rm -f $@
+docker-compose build $@
+docker-compose up -d $@

--- a/bin/redis-cli
+++ b/bin/redis-cli
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker compose run --rm redis redis-cli -h redis -n 1 "$@"
+docker-compose run --rm redis redis-cli -h redis -n 1 "$@"

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker compose run --rm -e "RAILS_ENV=test" --entrypoint ./bin/rspec api $@
+docker-compose run --rm -e "RAILS_ENV=test" --entrypoint ./bin/rspec api $@

--- a/bin/start
+++ b/bin/start
@@ -2,7 +2,7 @@
 
 cd "$(dirname "$0")/../"
 
-docker compose up -d $@
+docker-compose up -d $@
 
 echo "Listening at http://localhost:$(./bin/port)/"
 echo "Logs are available via \`bin/logs\`"

--- a/bin/status
+++ b/bin/status
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker compose ps
+docker-compose ps

--- a/bin/stop
+++ b/bin/stop
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker compose stop $@
+docker-compose stop $@

--- a/bin/testem
+++ b/bin/testem
@@ -19,4 +19,4 @@ function stop_listening {
 
 trap stop_listening EXIT
 
-docker compose run --rm --publish=7357:7357 client test --server
+docker-compose run --rm --publish=7357:7357 client test --server

--- a/bin/yarn
+++ b/bin/yarn
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker compose run --rm --entrypoint yarn client $@
+docker-compose run --rm --entrypoint yarn client $@

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
     depends_on: [postgres, redis, elasticsearch, mailcatcher, minio]
     build:
       context: ./server
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile.local
     volumes:
       - ./server:/opt/kitsu/server
       - uploads:/opt/kitsu/server/public/system

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
     depends_on: [postgres, redis, elasticsearch, mailcatcher, minio]
     build:
       context: ./server
-      dockerfile: Dockerfile.local
+      dockerfile: Dockerfile
     volumes:
       - ./server:/opt/kitsu/server
       - uploads:/opt/kitsu/server/public/system


### PR DESCRIPTION
This fixes a problem I had with setting a development environment.

**Changes proposed in this pull request:**
- The setup scripts were calling `docker compose` instead of `docker-compose`.
- [`docker-compose.yml`](https://github.com/hummingbird-me/kitsu-tools/blob/the-future/docker-compose.yml) also referred to a nonexistent Dockerfile in the server repository, so I corrected that as well.

cc @hummingbird-me/owners