### PR TITLE
Replace gzip to cat since download file is already normal file

### DIFF
--- a/bin/attach
+++ b/bin/attach
@@ -10,4 +10,4 @@ IFS='/' read -ra ADDR <<< "$BINDIR"
 POS=$((${#ADDR[@]} - 2))
 DIR=${ADDR[$POS]}
 
-docker exec -it "${DIR}_$1_1" /bin/bash
+docker exec -it "${DIR}-$1-1" /bin/bash || docker exec -it "${DIR}-$1-1" /bin/sh


### PR DESCRIPTION
Replace gzip to cat since download file is already normal file

Test Result:

download file url link in bin/seed: 
root# wget https://f002.backblazeb2.com/file/kitsu-dumps/latest.sql.gz
root# file latest.sql.gz
latest.sql.gz: ASCII text
#can start import data base use following command
root# cat latest.sql.gz ./bin/psql    

cc @hummingbird-me/owners
