### PR TITLE
Improve bin/attach

### DIFF
--- a/bin/attach
+++ b/bin/attach
@@ -10,4 +10,4 @@ IFS='/' read -ra ADDR <<< "$BINDIR"
 POS=$((${#ADDR[@]} - 2))
 DIR=${ADDR[$POS]}
 
-docker exec -it "${DIR}_$1_1" /bin/bash
+docker exec -it "${DIR}-$1-1" /bin/bash || docker exec -it "${DIR}-$1-1" /bin/sh


### PR DESCRIPTION
Improve bin/attach

1) The socker name using "-" instead of "_" now, for example: kitsu-tools-web-1

2) Some docker has no bash, so we can use sh instead

./bin/attach web
OCI runtime exec failed: exec failed: unable to start container process: exec: "/bin/bash": stat /bin/bash: no such file or directory: unknown



cc @hummingbird-me/owners
